### PR TITLE
Fix bug with consecutive semicolons in sourcemap mappings 

### DIFF
--- a/src/SourcemapToolkit.SourcemapParser/MappingListParser.cs
+++ b/src/SourcemapToolkit.SourcemapParser/MappingListParser.cs
@@ -199,13 +199,13 @@ namespace SourcemapToolkit.SourcemapParser
 
 			// The V3 source map format calls for all Base64 VLQ segments to be seperated by commas.
 			// Each line of generated code is separated using semicolons. The count of semicolons encountered gives the current line number.
-			string[] lines = mappingString.Split(new[] { ";" }, StringSplitOptions.RemoveEmptyEntries);
+			string[] lines = mappingString.Split(';');
 
 			for (int lineNumber = 0; lineNumber < lines.Length; lineNumber += 1)
 			{
 				// The only value that resets when encountering a semicolon is the starting column.
 				currentMappingsParserState = new MappingsParserState(currentMappingsParserState, newGeneratedLineNumber:lineNumber, newGeneratedColumnBase: 0);
-				string[] segmentsForLine = lines[lineNumber].Split(',');
+				string[] segmentsForLine = lines[lineNumber].Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
 
 				foreach (string segment in segmentsForLine)
 				{

--- a/tests/SourcemapToolkit.SourcemapParser.UnitTests/MappingsListParserUnitTests.cs
+++ b/tests/SourcemapToolkit.SourcemapParser.UnitTests/MappingsListParserUnitTests.cs
@@ -179,5 +179,23 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 			Assert.AreEqual(0, mappingsList[0].GeneratedSourcePosition.ZeroBasedLineNumber);
 			Assert.AreEqual(1, mappingsList[1].GeneratedSourcePosition.ZeroBasedLineNumber);
 		}
+
+		[TestMethod]
+		public void ParseMappings_BackToBackSemiColons_GeneratedLineNumberIncremented()
+		{
+			// Arrange
+			MappingsListParser mappingsListParser = new MappingsListParser();
+			string mappingsString = "ktC;;2iB";
+			List<string> names = new List<string>();
+			List<string> sources = new List<string>();
+
+			// Act
+			List<MappingEntry> mappingsList = mappingsListParser.ParseMappings(mappingsString, names, sources);
+
+			// Assert
+			Assert.AreEqual(2, mappingsList.Count);
+			Assert.AreEqual(0, mappingsList[0].GeneratedSourcePosition.ZeroBasedLineNumber);
+			Assert.AreEqual(2, mappingsList[1].GeneratedSourcePosition.ZeroBasedLineNumber);
+		}
 	}
 }


### PR DESCRIPTION
Right now if a mapping entry has consecutive semicolons, we only increment the line number once. This was due to the code that removes empty entries when doing the string.split on the semicolon. This change will instead remove the empty entries in the comma split step, which will prevent the call of the segment split code with the empty string as input.
