### PR TITLE
There's a crash when we are able to get a wrapping function, but the …

### DIFF
--- a/src/SourceMapToolkit.CallstackDeminifier/StackFrameDeminifier.cs
+++ b/src/SourceMapToolkit.CallstackDeminifier/StackFrameDeminifier.cs
@@ -65,7 +65,7 @@ namespace SourcemapToolkit.CallstackDeminifier
 				if (wrappingFunction.Bindings.Count == 2)
 				{
 					MappingEntry objectProtoypeMappingEntry =
-						sourceMap.GetMappingEntryForGeneratedSourcePosition(wrappingFunction.Bindings[0].SourcePosition);
+						sourceMap?.GetMappingEntryForGeneratedSourcePosition(wrappingFunction.Bindings[0].SourcePosition);
 
 					methodName = objectProtoypeMappingEntry?.OriginalName;
 				}


### PR DESCRIPTION
…source map is null.