### PR TITLE
Add method to reduce maps to just line mappings

### DIFF
--- a/src/SourcemapToolkit.SourcemapParser/MappingEntry.cs
+++ b/src/SourcemapToolkit.SourcemapParser/MappingEntry.cs
@@ -28,8 +28,8 @@ namespace SourcemapToolkit.SourcemapParser
 		{
 			return new MappingEntry
 			{
-				GeneratedSourcePosition = this.GeneratedSourcePosition as SourcePosition,
-				OriginalSourcePosition = this.OriginalSourcePosition as SourcePosition,
+				GeneratedSourcePosition = this.GeneratedSourcePosition.Clone(),
+				OriginalSourcePosition = this.OriginalSourcePosition.Clone(),
 				OriginalFileName = this.OriginalFileName,
 				OriginalName = this.OriginalName
 			};

--- a/src/SourcemapToolkit.SourcemapParser/SourceMap.cs
+++ b/src/SourcemapToolkit.SourcemapParser/SourceMap.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace SourcemapToolkit.SourcemapParser
 {
@@ -112,42 +111,6 @@ namespace SourcemapToolkit.SourcemapParser
 
 			return newSourceMap;
 		}
-
-        /// <summary>
-        /// Removes column information from a source map
-        /// This can significantly reduce the size of source maps, if line numbers are correct
-        /// <returns>A new source map</returns>
-        /// </summary>
-        public SourceMap Flatten()
-        {
-            SourceMap newMap = new SourceMap
-            {
-                File = this.File,
-                Version = this.Version,
-                Mappings = this.Mappings == null ? null: this.Mappings.Clone() as string,
-                Sources = this.Sources == null ? null: this.Sources.Select(s => s).ToList(),
-                Names = this.Names == null ? null: this.Names.Select(s => s).ToList(),
-                ParsedMappings = new List<MappingEntry>()
-            };
-
-            HashSet<int> visitedLines = new HashSet<int>();
-
-            foreach (MappingEntry mapping in this.ParsedMappings)
-            {
-                int generatedLine = mapping.GeneratedSourcePosition.ZeroBasedLineNumber;
-
-                if (!visitedLines.Contains(generatedLine))
-                {
-                    visitedLines.Add(generatedLine);
-                    var newMapping = mapping.Clone();
-                    newMapping.GeneratedSourcePosition.ZeroBasedColumnNumber = 0;
-                    newMapping.OriginalSourcePosition.ZeroBasedColumnNumber = 0;
-                    newMap.ParsedMappings.Add(newMapping);
-                }
-            }
-
-            return newMap;
-        }
 
         /// <summary>
         /// Finds the mapping entry for the generated source position. If no exact match is found, it will attempt

--- a/src/SourcemapToolkit.SourcemapParser/SourceMapTransformer.cs
+++ b/src/SourcemapToolkit.SourcemapParser/SourceMapTransformer.cs
@@ -1,0 +1,44 @@
+﻿using System.Collections.Generic;
+
+namespace SourcemapToolkit.SourcemapParser
+{
+    public static class SourceMapTransformer
+    {
+        /// <summary>
+        /// Removes column information from a source map
+        /// This can significantly reduce the size of source maps
+        /// If there is a tie between mapping entries, the first generated line takes priority
+        /// <returns>A new source map</returns>
+        /// </summary>
+        public static SourceMap Flatten(SourceMap sourceMap)
+        {
+            SourceMap newMap = new SourceMap
+            {
+                File = sourceMap.File,
+                Version = sourceMap.Version,
+                Mappings = sourceMap.Mappings,
+                Sources = new List<string>(sourceMap.Sources),
+                Names = new List<string>(sourceMap.Names),
+                ParsedMappings = new List<MappingEntry>()
+            };
+
+            HashSet<int> visitedLines = new HashSet<int>();
+
+            foreach (MappingEntry mapping in sourceMap.ParsedMappings)
+            {
+                int generatedLine = mapping.GeneratedSourcePosition.ZeroBasedLineNumber;
+
+                if (!visitedLines.Contains(generatedLine))
+                {
+                    visitedLines.Add(generatedLine);
+                    var newMapping = mapping.Clone();
+                    newMapping.GeneratedSourcePosition.ZeroBasedColumnNumber = 0;
+                    newMapping.OriginalSourcePosition.ZeroBasedColumnNumber = 0;
+                    newMap.ParsedMappings.Add(newMapping);
+                }
+            }
+
+            return newMap;
+        }
+    }
+}

--- a/tests/SourcemapToolkit.SourcemapParser.UnitTests/SourceMapTransformerUnitTests.cs
+++ b/tests/SourcemapToolkit.SourcemapParser.UnitTests/SourceMapTransformerUnitTests.cs
@@ -1,0 +1,106 @@
+﻿using System.Collections.Generic;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace SourcemapToolkit.SourcemapParser.UnitTests
+{
+    /// <summary>
+    /// Summary description for SourceMapTransformerUnitTests
+    /// </summary>
+    [TestClass]
+    public class SourceMapTransformerUnitTests
+    {
+
+        [TestMethod]
+        public void FlattenMap_ReturnsOnlyLineInformation()
+        {
+            // Arrange
+            SourcePosition generated1 = UnitTestUtils.generateSourcePosition(lineNumber: 1, colNumber: 2);
+            SourcePosition original1 = UnitTestUtils.generateSourcePosition(lineNumber: 2, colNumber: 2);
+            MappingEntry mappingEntry = UnitTestUtils.getSimpleEntry(generated1, original1, "sourceOne.js");
+
+            SourceMap map = new SourceMap
+            {
+                File = "generated.js",
+                Sources = new List<string> { "sourceOne.js" },
+                ParsedMappings = new List<MappingEntry> { mappingEntry }
+            };
+
+            // Act
+            SourceMap linesOnlyMap = SourceMapTransformer.Flatten(map);
+
+            // Assert
+            Assert.IsNotNull(linesOnlyMap);
+            Assert.AreEqual(1, linesOnlyMap.Sources.Count);
+            Assert.AreEqual(1, linesOnlyMap.ParsedMappings.Count);
+            Assert.AreEqual(1, linesOnlyMap.ParsedMappings[0].GeneratedSourcePosition.ZeroBasedLineNumber);
+            Assert.AreEqual(0, linesOnlyMap.ParsedMappings[0].GeneratedSourcePosition.ZeroBasedColumnNumber);
+            Assert.AreEqual(2, linesOnlyMap.ParsedMappings[0].OriginalSourcePosition.ZeroBasedLineNumber);
+            Assert.AreEqual(0, linesOnlyMap.ParsedMappings[0].OriginalSourcePosition.ZeroBasedColumnNumber);
+        }
+
+        [TestMethod]
+        public void FlattenMap_MultipleMappingsSameLine_ReturnsOnlyOneMappingPerLine()
+        {
+            // Arrange
+            SourcePosition generated1 = UnitTestUtils.generateSourcePosition(lineNumber: 1, colNumber: 2);
+            SourcePosition original1 = UnitTestUtils.generateSourcePosition(lineNumber: 2, colNumber: 2);
+            MappingEntry mappingEntry = UnitTestUtils.getSimpleEntry(generated1, original1, "sourceOne.js");
+
+            SourcePosition generated2 = UnitTestUtils.generateSourcePosition(lineNumber: 1, colNumber: 5);
+            SourcePosition original2 = UnitTestUtils.generateSourcePosition(lineNumber: 2, colNumber: 5);
+            MappingEntry mappingEntry2 = UnitTestUtils.getSimpleEntry(generated2, original2, "sourceOne.js");
+
+            SourceMap map = new SourceMap
+            {
+                File = "generated.js",
+                Sources = new List<string> { "sourceOne.js" },
+                ParsedMappings = new List<MappingEntry> { mappingEntry, mappingEntry2 }
+            };
+
+            // Act
+            SourceMap linesOnlyMap = SourceMapTransformer.Flatten(map);
+
+            // Assert
+            Assert.IsNotNull(linesOnlyMap);
+            Assert.AreEqual(1, linesOnlyMap.Sources.Count);
+            Assert.AreEqual(1, linesOnlyMap.ParsedMappings.Count);
+            Assert.AreEqual(1, linesOnlyMap.ParsedMappings[0].GeneratedSourcePosition.ZeroBasedLineNumber);
+            Assert.AreEqual(0, linesOnlyMap.ParsedMappings[0].GeneratedSourcePosition.ZeroBasedColumnNumber);
+            Assert.AreEqual(2, linesOnlyMap.ParsedMappings[0].OriginalSourcePosition.ZeroBasedLineNumber);
+            Assert.AreEqual(0, linesOnlyMap.ParsedMappings[0].OriginalSourcePosition.ZeroBasedColumnNumber);
+        }
+
+        [TestMethod]
+        public void FlattenMap_MultipleOriginalLineToSameGeneratedLine_ReturnsFirstOriginalLine()
+        {
+            // Arrange
+            SourcePosition generated1 = UnitTestUtils.generateSourcePosition(lineNumber: 1, colNumber: 2);
+            SourcePosition original1 = UnitTestUtils.generateSourcePosition(lineNumber: 2, colNumber: 2);
+            MappingEntry mappingEntry = UnitTestUtils.getSimpleEntry(generated1, original1, "sourceOne.js");
+
+            SourcePosition generated2 = UnitTestUtils.generateSourcePosition(lineNumber: 1, colNumber: 3);
+            SourcePosition original2 = UnitTestUtils.generateSourcePosition(lineNumber: 3, colNumber: 5);
+            MappingEntry mappingEntry2 = UnitTestUtils.getSimpleEntry(generated2, original2, "sourceOne.js");
+
+            SourceMap map = new SourceMap
+            {
+                File = "generated.js",
+                Sources = new List<string> { "sourceOne.js" },
+                ParsedMappings = new List<MappingEntry> { mappingEntry, mappingEntry2 }
+            };
+
+            // Act
+            SourceMap linesOnlyMap = SourceMapTransformer.Flatten(map);
+
+            // Assert
+            Assert.IsNotNull(linesOnlyMap);
+            Assert.AreEqual(1, linesOnlyMap.Sources.Count);
+            Assert.AreEqual(1, linesOnlyMap.ParsedMappings.Count);
+            Assert.AreEqual(1, linesOnlyMap.ParsedMappings[0].GeneratedSourcePosition.ZeroBasedLineNumber);
+            Assert.AreEqual(0, linesOnlyMap.ParsedMappings[0].GeneratedSourcePosition.ZeroBasedColumnNumber);
+            Assert.AreEqual(2, linesOnlyMap.ParsedMappings[0].OriginalSourcePosition.ZeroBasedLineNumber);
+            Assert.AreEqual(0, linesOnlyMap.ParsedMappings[0].OriginalSourcePosition.ZeroBasedColumnNumber);
+        }
+    }
+}

--- a/tests/SourcemapToolkit.SourcemapParser.UnitTests/SourceMapUnitTests.cs
+++ b/tests/SourcemapToolkit.SourcemapParser.UnitTests/SourceMapUnitTests.cs
@@ -401,7 +401,7 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
             };
 
             // Act
-            SourceMap linesOnlyMap = map.Flatten();
+            SourceMap linesOnlyMap = SourceMapTransformer.Flatten(map);
 
             // Assert
             Assert.IsNotNull(linesOnlyMap);
@@ -433,7 +433,7 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
             };
 
             // Act
-            SourceMap linesOnlyMap = map.Flatten();
+            SourceMap linesOnlyMap = SourceMapTransformer.Flatten(map);
 
             // Assert
             Assert.IsNotNull(linesOnlyMap);
@@ -465,7 +465,7 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
             };
 
             // Act
-            SourceMap linesOnlyMap = map.Flatten();
+            SourceMap linesOnlyMap = SourceMapTransformer.Flatten(map);
 
             // Assert
             Assert.IsNotNull(linesOnlyMap);

--- a/tests/SourcemapToolkit.SourcemapParser.UnitTests/SourceMapUnitTests.cs
+++ b/tests/SourcemapToolkit.SourcemapParser.UnitTests/SourceMapUnitTests.cs
@@ -384,5 +384,97 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 			MappingEntry rootMapping = secondCombinedMap.GetMappingEntryForGeneratedSourcePosition(generated3);
 			Assert.AreEqual(0, rootMapping.OriginalSourcePosition.CompareTo(mapLevel2.OriginalSourcePosition));
 		}
-	}
+
+        [TestMethod]
+        public void FlattenMap_ReturnsOnlyLineInformation()
+        {
+            // Arrange
+            SourcePosition generated1 = generateSourcePosition(lineNumber: 1, colNumber: 2);
+            SourcePosition original1 = generateSourcePosition(lineNumber: 2, colNumber: 2);
+            MappingEntry mappingEntry = getSimpleEntry(generated1, original1, "sourceOne.js");
+
+            SourceMap map = new SourceMap
+            {
+                File = "generated.js",
+                Sources = new List<string> { "sourceOne.js" },
+                ParsedMappings = new List<MappingEntry> { mappingEntry }
+            };
+
+            // Act
+            SourceMap linesOnlyMap = map.Flatten();
+
+            // Assert
+            Assert.IsNotNull(linesOnlyMap);
+            Assert.AreEqual(1, linesOnlyMap.Sources.Count);
+            Assert.AreEqual(1, linesOnlyMap.ParsedMappings.Count);
+            Assert.AreEqual(1, linesOnlyMap.ParsedMappings[0].GeneratedSourcePosition.ZeroBasedLineNumber);
+            Assert.AreEqual(0, linesOnlyMap.ParsedMappings[0].GeneratedSourcePosition.ZeroBasedColumnNumber);
+            Assert.AreEqual(2, linesOnlyMap.ParsedMappings[0].OriginalSourcePosition.ZeroBasedLineNumber);
+            Assert.AreEqual(0, linesOnlyMap.ParsedMappings[0].OriginalSourcePosition.ZeroBasedColumnNumber);
+        }
+
+        [TestMethod]
+        public void FlattenMap_MultipleMappingsSameLine_ReturnsOnlyOneMappingPerLine()
+        {
+            // Arrange
+            SourcePosition generated1 = generateSourcePosition(lineNumber: 1, colNumber: 2);
+            SourcePosition original1 = generateSourcePosition(lineNumber: 2, colNumber: 2);
+            MappingEntry mappingEntry = getSimpleEntry(generated1, original1, "sourceOne.js");
+
+            SourcePosition generated2 = generateSourcePosition(lineNumber: 1, colNumber: 5);
+            SourcePosition original2 = generateSourcePosition(lineNumber: 2, colNumber: 5);
+            MappingEntry mappingEntry2 = getSimpleEntry(generated2, original2, "sourceOne.js");
+
+            SourceMap map = new SourceMap
+            {
+                File = "generated.js",
+                Sources = new List<string> { "sourceOne.js" },
+                ParsedMappings = new List<MappingEntry> { mappingEntry, mappingEntry2 }
+            };
+
+            // Act
+            SourceMap linesOnlyMap = map.Flatten();
+
+            // Assert
+            Assert.IsNotNull(linesOnlyMap);
+            Assert.AreEqual(1, linesOnlyMap.Sources.Count);
+            Assert.AreEqual(1, linesOnlyMap.ParsedMappings.Count);
+            Assert.AreEqual(1, linesOnlyMap.ParsedMappings[0].GeneratedSourcePosition.ZeroBasedLineNumber);
+            Assert.AreEqual(0, linesOnlyMap.ParsedMappings[0].GeneratedSourcePosition.ZeroBasedColumnNumber);
+            Assert.AreEqual(2, linesOnlyMap.ParsedMappings[0].OriginalSourcePosition.ZeroBasedLineNumber);
+            Assert.AreEqual(0, linesOnlyMap.ParsedMappings[0].OriginalSourcePosition.ZeroBasedColumnNumber);
+        }
+
+        [TestMethod]
+        public void FlattenMap_MultipleOriginalLineToSameGeneratedLine_ReturnsFirstOriginalLine()
+        {
+            // Arrange
+            SourcePosition generated1 = generateSourcePosition(lineNumber: 1, colNumber: 2);
+            SourcePosition original1 = generateSourcePosition(lineNumber: 2, colNumber: 2);
+            MappingEntry mappingEntry = getSimpleEntry(generated1, original1, "sourceOne.js");
+
+            SourcePosition generated2 = generateSourcePosition(lineNumber: 1, colNumber: 3);
+            SourcePosition original2 = generateSourcePosition(lineNumber: 3, colNumber: 5);
+            MappingEntry mappingEntry2 = getSimpleEntry(generated2, original2, "sourceOne.js");
+
+            SourceMap map = new SourceMap
+            {
+                File = "generated.js",
+                Sources = new List<string> { "sourceOne.js" },
+                ParsedMappings = new List<MappingEntry> { mappingEntry, mappingEntry2 }
+            };
+
+            // Act
+            SourceMap linesOnlyMap = map.Flatten();
+
+            // Assert
+            Assert.IsNotNull(linesOnlyMap);
+            Assert.AreEqual(1, linesOnlyMap.Sources.Count);
+            Assert.AreEqual(1, linesOnlyMap.ParsedMappings.Count);
+            Assert.AreEqual(1, linesOnlyMap.ParsedMappings[0].GeneratedSourcePosition.ZeroBasedLineNumber);
+            Assert.AreEqual(0, linesOnlyMap.ParsedMappings[0].GeneratedSourcePosition.ZeroBasedColumnNumber);
+            Assert.AreEqual(2, linesOnlyMap.ParsedMappings[0].OriginalSourcePosition.ZeroBasedLineNumber);
+            Assert.AreEqual(0, linesOnlyMap.ParsedMappings[0].OriginalSourcePosition.ZeroBasedColumnNumber);
+        }
+    }
 }

--- a/tests/SourcemapToolkit.SourcemapParser.UnitTests/SourceMapUnitTests.cs
+++ b/tests/SourcemapToolkit.SourcemapParser.UnitTests/SourceMapUnitTests.cs
@@ -120,32 +120,13 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
             Assert.AreEqual(matchingMappingEntry, result);
         }
 
-		private MappingEntry getSimpleEntry(SourcePosition generatedSourcePosition, SourcePosition originalSourcePosition, string originalFileName)
-		{
-			return new MappingEntry
-			{
-				GeneratedSourcePosition = generatedSourcePosition,
-				OriginalSourcePosition = originalSourcePosition,
-				OriginalFileName = originalFileName
-			};
-		}
-
-		private SourcePosition generateSourcePosition(int lineNumber, int colNumber = 0)
-		{
-			return new SourcePosition
-			{
-				ZeroBasedLineNumber = lineNumber,
-				ZeroBasedColumnNumber = colNumber
-			};
-		}
-
 		[TestMethod]
 		public void GetRootMappingEntryForGeneratedSourcePosition_NoChildren_ReturnsSameEntry()
 		{
 			// Arrange
-			SourcePosition generated1 = generateSourcePosition(lineNumber:2, colNumber: 5);
-			SourcePosition original1 = generateSourcePosition(lineNumber:1, colNumber: 5);
-			MappingEntry mappingEntry = getSimpleEntry(generated1, original1, "generated.js");
+			SourcePosition generated1 = UnitTestUtils.generateSourcePosition(lineNumber:2, colNumber: 5);
+			SourcePosition original1 = UnitTestUtils.generateSourcePosition(lineNumber:1, colNumber: 5);
+			MappingEntry mappingEntry = UnitTestUtils.getSimpleEntry(generated1, original1, "generated.js");
 
 			SourceMap sourceMap = new SourceMap
 			{
@@ -165,9 +146,9 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 		public void ApplyMap_NullSubmap_ThrowsException()
 		{
 			// Arrange
-			SourcePosition generated2 = generateSourcePosition(lineNumber:3, colNumber: 5);
-			SourcePosition original2 = generateSourcePosition(lineNumber:2, colNumber: 5);
-			MappingEntry mapping = getSimpleEntry(generated2, original2, "sourceOne.js");
+			SourcePosition generated2 = UnitTestUtils.generateSourcePosition(lineNumber:3, colNumber: 5);
+			SourcePosition original2 = UnitTestUtils.generateSourcePosition(lineNumber:2, colNumber: 5);
+			MappingEntry mapping = UnitTestUtils.getSimpleEntry(generated2, original2, "sourceOne.js");
 
 			SourceMap map = new SourceMap
 			{
@@ -186,9 +167,9 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 		public void ApplyMap_NoMatchingSources_ReturnsSameMap()
 		{
 			// Arrange
-			SourcePosition generated1 = generateSourcePosition(lineNumber:2, colNumber: 3);
-			SourcePosition original1 = generateSourcePosition(lineNumber:1, colNumber: 2);
-			MappingEntry childMapping = getSimpleEntry(generated1, original1, "someOtherSource.js");
+			SourcePosition generated1 = UnitTestUtils.generateSourcePosition(lineNumber:2, colNumber: 3);
+			SourcePosition original1 = UnitTestUtils.generateSourcePosition(lineNumber:1, colNumber: 2);
+			MappingEntry childMapping = UnitTestUtils.getSimpleEntry(generated1, original1, "someOtherSource.js");
 
 			SourceMap childMap = new SourceMap
 			{
@@ -197,9 +178,9 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 				ParsedMappings = new List<MappingEntry> { childMapping }
 			};
 
-			SourcePosition generated2 = generateSourcePosition(lineNumber:3, colNumber: 7);
-			SourcePosition original2 = generateSourcePosition(lineNumber:2, colNumber: 3);
-			MappingEntry parentMapping = getSimpleEntry(generated2, original2, "sourceOne.js");
+			SourcePosition generated2 = UnitTestUtils.generateSourcePosition(lineNumber:3, colNumber: 7);
+			SourcePosition original2 = UnitTestUtils.generateSourcePosition(lineNumber:2, colNumber: 3);
+			MappingEntry parentMapping = UnitTestUtils.getSimpleEntry(generated2, original2, "sourceOne.js");
 
 			SourceMap parentMap = new SourceMap
 			{
@@ -221,9 +202,9 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
         public void ApplyMap_NoMatchingMappings_ReturnsSameMap()
         {
             // Arrange
-            SourcePosition generated1 = generateSourcePosition(lineNumber: 2, colNumber:2);
-            SourcePosition original1 = generateSourcePosition(lineNumber: 1, colNumber:10);
-            MappingEntry childMapping = getSimpleEntry(generated1, original1, "sourceTwo.js");
+            SourcePosition generated1 = UnitTestUtils.generateSourcePosition(lineNumber: 2, colNumber:2);
+            SourcePosition original1 = UnitTestUtils.generateSourcePosition(lineNumber: 1, colNumber:10);
+            MappingEntry childMapping = UnitTestUtils.getSimpleEntry(generated1, original1, "sourceTwo.js");
 
             SourceMap childMap = new SourceMap
             {
@@ -232,9 +213,9 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
                 ParsedMappings = new List<MappingEntry> { childMapping }
             };
 
-            SourcePosition generated2 = generateSourcePosition(lineNumber:3, colNumber:4);
-            SourcePosition original2 = generateSourcePosition(lineNumber:2, colNumber:5);
-            MappingEntry parentMapping = getSimpleEntry(generated2, original2, "sourceOne.js");
+            SourcePosition generated2 = UnitTestUtils.generateSourcePosition(lineNumber:3, colNumber:4);
+            SourcePosition original2 = UnitTestUtils.generateSourcePosition(lineNumber:2, colNumber:5);
+            MappingEntry parentMapping = UnitTestUtils.getSimpleEntry(generated2, original2, "sourceOne.js");
 
             SourceMap parentMap = new SourceMap
             {
@@ -258,9 +239,9 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
             // Expect mapping with same source filename as the applied source-map to be replaced
 
             // Arrange
-            SourcePosition generated1 = generateSourcePosition(lineNumber:2, colNumber:4);
-			SourcePosition original1 = generateSourcePosition(lineNumber:1, colNumber:3);
-			MappingEntry childMapping = getSimpleEntry(generated1, original1, "sourceTwo.js");
+            SourcePosition generated1 = UnitTestUtils.generateSourcePosition(lineNumber:2, colNumber:4);
+			SourcePosition original1 = UnitTestUtils.generateSourcePosition(lineNumber:1, colNumber:3);
+			MappingEntry childMapping = UnitTestUtils.getSimpleEntry(generated1, original1, "sourceTwo.js");
 
 			SourceMap childMap = new SourceMap
 			{
@@ -269,9 +250,9 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 				ParsedMappings = new List<MappingEntry> { childMapping }
 			};
 
-			SourcePosition generated2 = generateSourcePosition(lineNumber:3, colNumber: 5);
-			SourcePosition original2 = generateSourcePosition(lineNumber:2, colNumber: 4);
-			MappingEntry parentMapping = getSimpleEntry(generated2, original2, "sourceOne.js");
+			SourcePosition generated2 = UnitTestUtils.generateSourcePosition(lineNumber:3, colNumber: 5);
+			SourcePosition original2 = UnitTestUtils.generateSourcePosition(lineNumber:2, colNumber: 4);
+			MappingEntry parentMapping = UnitTestUtils.getSimpleEntry(generated2, original2, "sourceOne.js");
 
 			SourceMap parentMap = new SourceMap
 			{
@@ -298,9 +279,9 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
             // mappings with a different source filename should stay the same
 
             // Arrange
-            SourcePosition generated1 = generateSourcePosition(lineNumber:2, colNumber:10);
-			SourcePosition original1 = generateSourcePosition(lineNumber:1, colNumber:5);
-			MappingEntry childMapping = getSimpleEntry(generated1, original1, "sourceTwo.js");
+            SourcePosition generated1 = UnitTestUtils.generateSourcePosition(lineNumber:2, colNumber:10);
+			SourcePosition original1 = UnitTestUtils.generateSourcePosition(lineNumber:1, colNumber:5);
+			MappingEntry childMapping = UnitTestUtils.getSimpleEntry(generated1, original1, "sourceTwo.js");
 
 			SourceMap childMap = new SourceMap
 			{
@@ -309,13 +290,13 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 				ParsedMappings = new List<MappingEntry> { childMapping }
 			};
 
-			SourcePosition generated2 = generateSourcePosition(lineNumber:3, colNumber:2);
-			SourcePosition original2 = generateSourcePosition(lineNumber:2, colNumber: 10);
-			MappingEntry mapping = getSimpleEntry(generated2, original2, "sourceOne.js");
+			SourcePosition generated2 = UnitTestUtils.generateSourcePosition(lineNumber:3, colNumber:2);
+			SourcePosition original2 = UnitTestUtils.generateSourcePosition(lineNumber:2, colNumber: 10);
+			MappingEntry mapping = UnitTestUtils.getSimpleEntry(generated2, original2, "sourceOne.js");
 
-			SourcePosition generated3 = generateSourcePosition(lineNumber:4, colNumber:3);
-			SourcePosition original3 = generateSourcePosition(lineNumber:3, colNumber:2);
-			MappingEntry mapping2 = getSimpleEntry(generated3, original3, "noMapForThis.js");
+			SourcePosition generated3 = UnitTestUtils.generateSourcePosition(lineNumber:4, colNumber:3);
+			SourcePosition original3 = UnitTestUtils.generateSourcePosition(lineNumber:3, colNumber:2);
+			MappingEntry mapping2 = UnitTestUtils.getSimpleEntry(generated3, original3, "noMapForThis.js");
 
 			SourceMap parentMap = new SourceMap
 			{
@@ -341,9 +322,9 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 		public void ApplyMap_ExactMatchDeep_ReturnsCorrectMappingEntry()
 		{
 			// Arrange
-			SourcePosition generated1 = generateSourcePosition(lineNumber:3, colNumber:5);
-			SourcePosition original1 = generateSourcePosition(lineNumber:2, colNumber:10);
-			MappingEntry mapLevel2 = getSimpleEntry(generated1, original1, "sourceThree.js");
+			SourcePosition generated1 = UnitTestUtils.generateSourcePosition(lineNumber:3, colNumber:5);
+			SourcePosition original1 = UnitTestUtils.generateSourcePosition(lineNumber:2, colNumber:10);
+			MappingEntry mapLevel2 = UnitTestUtils.getSimpleEntry(generated1, original1, "sourceThree.js");
 
 			SourceMap grandChildMap = new SourceMap
 			{
@@ -352,9 +333,9 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 				ParsedMappings = new List<MappingEntry> { mapLevel2 }
 			};
 
-			SourcePosition generated2 = generateSourcePosition(lineNumber:4, colNumber:3);
-			SourcePosition original2 = generateSourcePosition(lineNumber:3, colNumber:5);
-			MappingEntry mapLevel1 = getSimpleEntry(generated2, original2, "sourceTwo.js");
+			SourcePosition generated2 = UnitTestUtils.generateSourcePosition(lineNumber:4, colNumber:3);
+			SourcePosition original2 = UnitTestUtils.generateSourcePosition(lineNumber:3, colNumber:5);
+			MappingEntry mapLevel1 = UnitTestUtils.getSimpleEntry(generated2, original2, "sourceTwo.js");
 
 			SourceMap childMap = new SourceMap
 			{
@@ -363,9 +344,9 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 				ParsedMappings = new List<MappingEntry> { mapLevel1 }
 			};
 
-			SourcePosition generated3 = generateSourcePosition(lineNumber:5, colNumber:5);
-			SourcePosition original3 = generateSourcePosition(lineNumber:4, colNumber:3);
-			MappingEntry mapLevel0 = getSimpleEntry(generated3, original3, "sourceOne.js");
+			SourcePosition generated3 = UnitTestUtils.generateSourcePosition(lineNumber:5, colNumber:5);
+			SourcePosition original3 = UnitTestUtils.generateSourcePosition(lineNumber:4, colNumber:3);
+			MappingEntry mapLevel0 = UnitTestUtils.getSimpleEntry(generated3, original3, "sourceOne.js");
 
 			SourceMap parentMap = new SourceMap
 			{
@@ -384,97 +365,5 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 			MappingEntry rootMapping = secondCombinedMap.GetMappingEntryForGeneratedSourcePosition(generated3);
 			Assert.AreEqual(0, rootMapping.OriginalSourcePosition.CompareTo(mapLevel2.OriginalSourcePosition));
 		}
-
-        [TestMethod]
-        public void FlattenMap_ReturnsOnlyLineInformation()
-        {
-            // Arrange
-            SourcePosition generated1 = generateSourcePosition(lineNumber: 1, colNumber: 2);
-            SourcePosition original1 = generateSourcePosition(lineNumber: 2, colNumber: 2);
-            MappingEntry mappingEntry = getSimpleEntry(generated1, original1, "sourceOne.js");
-
-            SourceMap map = new SourceMap
-            {
-                File = "generated.js",
-                Sources = new List<string> { "sourceOne.js" },
-                ParsedMappings = new List<MappingEntry> { mappingEntry }
-            };
-
-            // Act
-            SourceMap linesOnlyMap = SourceMapTransformer.Flatten(map);
-
-            // Assert
-            Assert.IsNotNull(linesOnlyMap);
-            Assert.AreEqual(1, linesOnlyMap.Sources.Count);
-            Assert.AreEqual(1, linesOnlyMap.ParsedMappings.Count);
-            Assert.AreEqual(1, linesOnlyMap.ParsedMappings[0].GeneratedSourcePosition.ZeroBasedLineNumber);
-            Assert.AreEqual(0, linesOnlyMap.ParsedMappings[0].GeneratedSourcePosition.ZeroBasedColumnNumber);
-            Assert.AreEqual(2, linesOnlyMap.ParsedMappings[0].OriginalSourcePosition.ZeroBasedLineNumber);
-            Assert.AreEqual(0, linesOnlyMap.ParsedMappings[0].OriginalSourcePosition.ZeroBasedColumnNumber);
-        }
-
-        [TestMethod]
-        public void FlattenMap_MultipleMappingsSameLine_ReturnsOnlyOneMappingPerLine()
-        {
-            // Arrange
-            SourcePosition generated1 = generateSourcePosition(lineNumber: 1, colNumber: 2);
-            SourcePosition original1 = generateSourcePosition(lineNumber: 2, colNumber: 2);
-            MappingEntry mappingEntry = getSimpleEntry(generated1, original1, "sourceOne.js");
-
-            SourcePosition generated2 = generateSourcePosition(lineNumber: 1, colNumber: 5);
-            SourcePosition original2 = generateSourcePosition(lineNumber: 2, colNumber: 5);
-            MappingEntry mappingEntry2 = getSimpleEntry(generated2, original2, "sourceOne.js");
-
-            SourceMap map = new SourceMap
-            {
-                File = "generated.js",
-                Sources = new List<string> { "sourceOne.js" },
-                ParsedMappings = new List<MappingEntry> { mappingEntry, mappingEntry2 }
-            };
-
-            // Act
-            SourceMap linesOnlyMap = SourceMapTransformer.Flatten(map);
-
-            // Assert
-            Assert.IsNotNull(linesOnlyMap);
-            Assert.AreEqual(1, linesOnlyMap.Sources.Count);
-            Assert.AreEqual(1, linesOnlyMap.ParsedMappings.Count);
-            Assert.AreEqual(1, linesOnlyMap.ParsedMappings[0].GeneratedSourcePosition.ZeroBasedLineNumber);
-            Assert.AreEqual(0, linesOnlyMap.ParsedMappings[0].GeneratedSourcePosition.ZeroBasedColumnNumber);
-            Assert.AreEqual(2, linesOnlyMap.ParsedMappings[0].OriginalSourcePosition.ZeroBasedLineNumber);
-            Assert.AreEqual(0, linesOnlyMap.ParsedMappings[0].OriginalSourcePosition.ZeroBasedColumnNumber);
-        }
-
-        [TestMethod]
-        public void FlattenMap_MultipleOriginalLineToSameGeneratedLine_ReturnsFirstOriginalLine()
-        {
-            // Arrange
-            SourcePosition generated1 = generateSourcePosition(lineNumber: 1, colNumber: 2);
-            SourcePosition original1 = generateSourcePosition(lineNumber: 2, colNumber: 2);
-            MappingEntry mappingEntry = getSimpleEntry(generated1, original1, "sourceOne.js");
-
-            SourcePosition generated2 = generateSourcePosition(lineNumber: 1, colNumber: 3);
-            SourcePosition original2 = generateSourcePosition(lineNumber: 3, colNumber: 5);
-            MappingEntry mappingEntry2 = getSimpleEntry(generated2, original2, "sourceOne.js");
-
-            SourceMap map = new SourceMap
-            {
-                File = "generated.js",
-                Sources = new List<string> { "sourceOne.js" },
-                ParsedMappings = new List<MappingEntry> { mappingEntry, mappingEntry2 }
-            };
-
-            // Act
-            SourceMap linesOnlyMap = SourceMapTransformer.Flatten(map);
-
-            // Assert
-            Assert.IsNotNull(linesOnlyMap);
-            Assert.AreEqual(1, linesOnlyMap.Sources.Count);
-            Assert.AreEqual(1, linesOnlyMap.ParsedMappings.Count);
-            Assert.AreEqual(1, linesOnlyMap.ParsedMappings[0].GeneratedSourcePosition.ZeroBasedLineNumber);
-            Assert.AreEqual(0, linesOnlyMap.ParsedMappings[0].GeneratedSourcePosition.ZeroBasedColumnNumber);
-            Assert.AreEqual(2, linesOnlyMap.ParsedMappings[0].OriginalSourcePosition.ZeroBasedLineNumber);
-            Assert.AreEqual(0, linesOnlyMap.ParsedMappings[0].OriginalSourcePosition.ZeroBasedColumnNumber);
-        }
     }
 }

--- a/tests/SourcemapToolkit.SourcemapParser.UnitTests/UnitTestUtils.cs
+++ b/tests/SourcemapToolkit.SourcemapParser.UnitTests/UnitTestUtils.cs
@@ -10,5 +10,24 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 			byte[] byteArray = Encoding.UTF8.GetBytes(streamContents);
 			return new StreamReader(new MemoryStream(byteArray));
 		}
-	}
+
+        public static MappingEntry getSimpleEntry(SourcePosition generatedSourcePosition, SourcePosition originalSourcePosition, string originalFileName)
+        {
+            return new MappingEntry
+            {
+                GeneratedSourcePosition = generatedSourcePosition,
+                OriginalSourcePosition = originalSourcePosition,
+                OriginalFileName = originalFileName
+            };
+        }
+
+        public static SourcePosition generateSourcePosition(int lineNumber, int colNumber = 0)
+        {
+            return new SourcePosition
+            {
+                ZeroBasedLineNumber = lineNumber,
+                ZeroBasedColumnNumber = colNumber
+            };
+        }
+    }
 }


### PR DESCRIPTION
Large Javascript files can have unnecessarily big map files. I've done some prototyping with sample Typescript code, with all column information in mappings removed. The maps works fine.

This also makes our use case of applying line-information only source maps (e.g bundling) against denser maps produced by Typescript compiler. Example, instead of doing this (* is for any column)

a.ts -> a.js:
(1, 3) -> (3, 3)
(1, 4) -> (3, 4)

a.js -> a.js':
(3, *) -> (4, *)

into:
a.ts -> a.js':
(1, 3) -> (4, 3)
(1, 4) -> (4, 4)

We can just do this:
flatten a.ts -> a.js:
(1, 0) -> (3, 0)

a.js -> a.js':
(3, 0) -> (4, 0)

then applying maps:
a.ts -> a.js':
(1, 0) -> (4, 0)

Webpack also supports multiple forms of [lines-only mappings](https://webpack.js.org/configuration/devtool/), reducing the size of the map
