### PR TITLE
Add overload to GetStackTraceDeminfier and GetMethodNameOnlyStackTraceDeminfier

### DIFF
--- a/src/SourceMapToolkit.CallstackDeminifier/StackTraceDeminfierFactory.cs
+++ b/src/SourceMapToolkit.CallstackDeminifier/StackTraceDeminfierFactory.cs
@@ -5,7 +5,7 @@ namespace SourcemapToolkit.CallstackDeminifier
 {
 	public class StackTraceDeminfierFactory
 	{
-		private static void ValidateArguments(ISourceMapProvider sourceMapProvider, ISourceCodeProvider generatedCodeProvider)
+		private static void ValidateArguments(ISourceMapProvider sourceMapProvider, ISourceCodeProvider generatedCodeProvider, IStackTraceParser stackTraceParser)
 		{
 			if (sourceMapProvider == null)
 			{
@@ -16,6 +16,11 @@ namespace SourcemapToolkit.CallstackDeminifier
 			{
 				throw new ArgumentNullException(nameof(generatedCodeProvider));
 			}
+
+			if (stackTraceParser == null)
+			{
+				throw new ArgumentNullException(nameof(stackTraceParser));
+			}
 		}
 
 		/// <summary>
@@ -25,17 +30,26 @@ namespace SourcemapToolkit.CallstackDeminifier
 		/// <param name="generatedCodeProvider">Consumers of the API should implement this interface, which provides the contents of a JavaScript file. Throws ArgumentNullException if the parameter is set to null.</param>
 		public static StackTraceDeminifier GetStackTraceDeminfier(ISourceMapProvider sourceMapProvider, ISourceCodeProvider generatedCodeProvider)
 		{
-			ValidateArguments(sourceMapProvider, generatedCodeProvider);
+			return GetStackTraceDeminfier(sourceMapProvider, generatedCodeProvider, new StackTraceParser());
+		}
 
+		/// <summary>
+		/// Creates a StackTraceDeminifier with full capabilities. StackTrace deminifiers created with this method will keep source maps cached, and thus use significantly more memory during runtime than the ones generated with GetMethodNameOnlyStackTraceDeminfier.
+		/// </summary>
+		/// <param name="sourceMapProvider">Consumers of the API should implement this interface, which provides the source map for a given JavaScript file. Throws ArgumentNullException if the parameter is set to null.</param>
+		/// <param name="generatedCodeProvider">Consumers of the API should implement this interface, which provides the contents of a JavaScript file. Throws ArgumentNullException if the parameter is set to null.</param>
+		/// <param name="stackTraceParser">Consumers of the API should implement this interface, which provides a parser for the stacktrace. Throws ArgumentNullException if the parameter is set to null.</param>
+		public static StackTraceDeminifier GetStackTraceDeminfier(ISourceMapProvider sourceMapProvider, ISourceCodeProvider generatedCodeProvider, IStackTraceParser stackTraceParser)
+		{
+			ValidateArguments(sourceMapProvider, generatedCodeProvider, stackTraceParser);
+			
 			ISourceMapStore sourceMapStore = new SourceMapStore(sourceMapProvider);
 			IStackFrameDeminifier stackFrameDeminifier = new StackFrameDeminifier(sourceMapStore,
 				new FunctionMapStore(generatedCodeProvider, sourceMapStore.GetSourceMapForUrl), new FunctionMapConsumer());
 
-			IStackTraceParser stackTraceParser = new StackTraceParser();
-
 			return new StackTraceDeminifier(stackFrameDeminifier, stackTraceParser);
 		}
-
+		
 		/// <summary>
 		/// Creates a StackTraceDeminifier that only deminifies the method names. StackTrace deminifiers created with this method will use significantly less memory during runtime than the 
 		/// </summary>
@@ -43,12 +57,21 @@ namespace SourcemapToolkit.CallstackDeminifier
 		/// <param name="generatedCodeProvider">Consumers of the API should implement this interface, which provides the contents of a JavaScript file. Throws ArgumentNullException if the parameter is set to null.</param>
 		public static StackTraceDeminifier GetMethodNameOnlyStackTraceDeminfier(ISourceMapProvider sourceMapProvider, ISourceCodeProvider generatedCodeProvider)
 		{
-			ValidateArguments(sourceMapProvider, generatedCodeProvider);
-
+			return GetMethodNameOnlyStackTraceDeminfier(sourceMapProvider, generatedCodeProvider, new StackTraceParser());
+		}
+		
+		/// <summary>
+		/// Creates a StackTraceDeminifier that only deminifies the method names. StackTrace deminifiers created with this method will use significantly less memory during runtime than the 
+		/// </summary>
+		/// <param name="sourceMapProvider">Consumers of the API should implement this interface, which provides the source map for a given JavaScript file. Throws ArgumentNullException if the parameter is set to null.</param>
+		/// <param name="generatedCodeProvider">Consumers of the API should implement this interface, which provides the contents of a JavaScript file. Throws ArgumentNullException if the parameter is set to null.</param>
+		/// <param name="stackTraceParser">Consumers of the API should implement this interface, which provides a parser for the stacktrace. Throws ArgumentNullException if the parameter is set to null.</param>
+		public static StackTraceDeminifier GetMethodNameOnlyStackTraceDeminfier(ISourceMapProvider sourceMapProvider, ISourceCodeProvider generatedCodeProvider, IStackTraceParser stackTraceParser)
+		{
+			ValidateArguments(sourceMapProvider, generatedCodeProvider, stackTraceParser);
+			
 			SourceMapParser sourceMapParser = new SourceMapParser();
 			IStackFrameDeminifier stackFrameDeminifier = new SimpleStackFrameDeminifier(new FunctionMapStore(generatedCodeProvider, (url) => sourceMapParser.ParseSourceMap(sourceMapProvider.GetSourceMapContentsForCallstackUrl(url))), new FunctionMapConsumer());
-
-			IStackTraceParser stackTraceParser = new StackTraceParser();
 
 			return new StackTraceDeminifier(stackFrameDeminifier, stackTraceParser);
 		}


### PR DESCRIPTION
The new overloads allow a user to supply their own implementations of
IStackTraceParser to acommedate a larger varaity of JS stacktraces.