### PR TITLE
Switch test-framework to xunit

### DIFF
--- a/tests/SourcemapToolkit.CallstackDeminifier.UnitTests/FunctionMapConsumerUnitTests.cs
+++ b/tests/SourcemapToolkit.CallstackDeminifier.UnitTests/FunctionMapConsumerUnitTests.cs
@@ -1,13 +1,13 @@
 ﻿using System.Collections.Generic;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 using SourcemapToolkit.SourcemapParser;
 
 namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 {
-	[TestClass]
+
 	public class FunctionMapConsumerUnitTests
 	{
-		[TestMethod]
+		[Fact]
 		public void GetWrappingFunctionForSourceLocation_EmptyFunctionMap_ReturnNull()
 		{
 			// Arrange
@@ -23,10 +23,10 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 			FunctionMapEntry wrappingFunction = functionMapConsumer.GetWrappingFunctionForSourceLocation(sourcePosition, functionMap);
 
 			// Assert
-			Assert.IsNull(wrappingFunction);
+			Assert.Null(wrappingFunction);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void GetWrappingFunctionForSourceLocation_SingleIrrelevantFunctionMapEntry_ReturnNull()
 		{
 			// Arrange
@@ -49,10 +49,10 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 			FunctionMapEntry wrappingFunction = functionMapConsumer.GetWrappingFunctionForSourceLocation(sourcePosition, functionMap);
 
 			// Assert
-			Assert.IsNull(wrappingFunction);
+			Assert.Null(wrappingFunction);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void GetWrappingFunctionForSourceLocation_SingleRelevantFunctionMapEntry_ReturnWrappingFunction()
 		{
 			// Arrange
@@ -76,10 +76,10 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 			FunctionMapEntry wrappingFunction = functionMapConsumer.GetWrappingFunctionForSourceLocation(sourcePosition, functionMap);
 
 			// Assert
-			Assert.AreEqual(functionMapEntry, wrappingFunction);
+			Assert.Equal(functionMapEntry, wrappingFunction);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void GetWrappingFunctionForSourceLocation_MultipleFunctionMapEntriesSingleRelevantFunctionMapEntry_ReturnWrappingFunction()
 		{
 			// Arrange
@@ -109,10 +109,10 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 			FunctionMapEntry wrappingFunction = functionMapConsumer.GetWrappingFunctionForSourceLocation(sourcePosition, functionMap);
 
 			// Assert
-			Assert.AreEqual(functionMapEntry2, wrappingFunction);
+			Assert.Equal(functionMapEntry2, wrappingFunction);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void GetWrappingFunctionForSourceLocation_MultipleFunctionMapEntriesMultipleRelevantFunctionMapEntry_ReturnClosestWrappingFunction()
 		{
 			// Arrange
@@ -142,7 +142,7 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 			FunctionMapEntry wrappingFunction = functionMapConsumer.GetWrappingFunctionForSourceLocation(sourcePosition, functionMap);
 
 			// Assert
-			Assert.AreEqual(functionMapEntry2, wrappingFunction);
+			Assert.Equal(functionMapEntry2, wrappingFunction);
 		}
 	}
 }

--- a/tests/SourcemapToolkit.CallstackDeminifier.UnitTests/FunctionMapGeneratorUnitTests.cs
+++ b/tests/SourcemapToolkit.CallstackDeminifier.UnitTests/FunctionMapGeneratorUnitTests.cs
@@ -1,16 +1,16 @@
 ﻿using System;
 using System.Collections.Generic;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 using SourcemapToolkit.SourcemapParser.UnitTests;
 using Rhino.Mocks;
 using SourcemapToolkit.SourcemapParser;
 
 namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 {
-	[TestClass]
+
 	public class FunctionMapGeneratorUnitTests
 	{
-		[TestMethod]
+		[Fact]
 		public void GenerateFunctionMap_NullSourceMap_ReturnsNull()
 		{
 			// Arrange
@@ -21,11 +21,11 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 			List<FunctionMapEntry> functionMap = functionMapGenerator.GenerateFunctionMap(UnitTestUtils.StreamReaderFromString(sourceCode), null);
 
 			// Assert
-			Assert.IsNull(functionMap);
+			Assert.Null(functionMap);
 		}
 
 
-		[TestMethod]
+		[Fact]
 		public void ParseSourceCode_NullInput_ReturnsNull()
 		{
 			// Arrange
@@ -35,10 +35,10 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 			List<FunctionMapEntry> functionMap = functionMapGenerator.ParseSourceCode(null);
 
 			// Assert
-			Assert.IsNull(functionMap);
+			Assert.Null(functionMap);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void ParseSourceCode_NoFunctionsInSource_EmptyFunctionList()
 		{
 			// Arrange
@@ -49,10 +49,10 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 			List<FunctionMapEntry> functionMap = functionMapGenerator.ParseSourceCode(UnitTestUtils.StreamReaderFromString(sourceCode));
 
 			// Assert
-			Assert.AreEqual(0, functionMap.Count);
+			Assert.Equal(0, functionMap.Count);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void ParseSourceCode_SingleLineFunctionInSource_CorrectZeroBasedColumnNumbers()
 		{
 			// Arrange
@@ -63,17 +63,17 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 			List<FunctionMapEntry> functionMap = functionMapGenerator.ParseSourceCode(UnitTestUtils.StreamReaderFromString(sourceCode));
 
 			// Assert
-			Assert.AreEqual(1, functionMap.Count);
-			Assert.AreEqual("foo", functionMap[0].Bindings[0].Name);
-			Assert.AreEqual(0, functionMap[0].Bindings[0].SourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(9, functionMap[0].Bindings[0].SourcePosition.ZeroBasedColumnNumber);
-			Assert.AreEqual(0, functionMap[0].StartSourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(0, functionMap[0].EndSourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(14, functionMap[0].StartSourcePosition.ZeroBasedColumnNumber);
-			Assert.AreEqual(22, functionMap[0].EndSourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal(1, functionMap.Count);
+			Assert.Equal("foo", functionMap[0].Bindings[0].Name);
+			Assert.Equal(0, functionMap[0].Bindings[0].SourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(9, functionMap[0].Bindings[0].SourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal(0, functionMap[0].StartSourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(0, functionMap[0].EndSourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(14, functionMap[0].StartSourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal(22, functionMap[0].EndSourcePosition.ZeroBasedColumnNumber);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void ParseSourceCode_MultiLineFunctionInSource_CorrectColumnAndZeroBasedLineNumbers()
 		{
 			// Arrange
@@ -85,17 +85,17 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 			List<FunctionMapEntry> functionMap = functionMapGenerator.ParseSourceCode(UnitTestUtils.StreamReaderFromString(sourceCode));
 
 			// Assert
-			Assert.AreEqual(1, functionMap.Count);
-			Assert.AreEqual("foo", functionMap[0].Bindings[0].Name);
-			Assert.AreEqual(0, functionMap[0].Bindings[0].SourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(9, functionMap[0].Bindings[0].SourcePosition.ZeroBasedColumnNumber);
-			Assert.AreEqual(1, functionMap[0].StartSourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(3, functionMap[0].EndSourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(0, functionMap[0].StartSourcePosition.ZeroBasedColumnNumber);
-			Assert.AreEqual(1, functionMap[0].EndSourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal(1, functionMap.Count);
+			Assert.Equal("foo", functionMap[0].Bindings[0].Name);
+			Assert.Equal(0, functionMap[0].Bindings[0].SourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(9, functionMap[0].Bindings[0].SourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal(1, functionMap[0].StartSourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(3, functionMap[0].EndSourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(0, functionMap[0].StartSourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal(1, functionMap[0].EndSourcePosition.ZeroBasedColumnNumber);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void ParseSourceCode_TwoSingleLineFunctions_TwoFunctionMapEntries()
 		{
 			// Arrange
@@ -106,26 +106,26 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 			List<FunctionMapEntry> functionMap = functionMapGenerator.ParseSourceCode(UnitTestUtils.StreamReaderFromString(sourceCode));
 
 			// Assert
-			Assert.AreEqual(2, functionMap.Count);
+			Assert.Equal(2, functionMap.Count);
 
-			Assert.AreEqual("bar", functionMap[0].Bindings[0].Name);
-			Assert.AreEqual(0, functionMap[0].Bindings[0].SourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(31, functionMap[0].Bindings[0].SourcePosition.ZeroBasedColumnNumber);
-			Assert.AreEqual(0, functionMap[0].StartSourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(0, functionMap[0].EndSourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(36, functionMap[0].StartSourcePosition.ZeroBasedColumnNumber);
-			Assert.AreEqual(44, functionMap[0].EndSourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal("bar", functionMap[0].Bindings[0].Name);
+			Assert.Equal(0, functionMap[0].Bindings[0].SourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(31, functionMap[0].Bindings[0].SourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal(0, functionMap[0].StartSourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(0, functionMap[0].EndSourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(36, functionMap[0].StartSourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal(44, functionMap[0].EndSourcePosition.ZeroBasedColumnNumber);
 
-			Assert.AreEqual("foo", functionMap[1].Bindings[0].Name);
-			Assert.AreEqual(0, functionMap[1].Bindings[0].SourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(9, functionMap[1].Bindings[0].SourcePosition.ZeroBasedColumnNumber);
-			Assert.AreEqual(0, functionMap[1].StartSourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(0, functionMap[1].EndSourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(14, functionMap[1].StartSourcePosition.ZeroBasedColumnNumber);
-			Assert.AreEqual(22, functionMap[1].EndSourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal("foo", functionMap[1].Bindings[0].Name);
+			Assert.Equal(0, functionMap[1].Bindings[0].SourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(9, functionMap[1].Bindings[0].SourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal(0, functionMap[1].StartSourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(0, functionMap[1].EndSourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(14, functionMap[1].StartSourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal(22, functionMap[1].EndSourcePosition.ZeroBasedColumnNumber);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void ParseSourceCode_TwoNestedSingleLineFunctions_TwoFunctionMapEntries()
 		{
 			// Arrange
@@ -136,26 +136,26 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 			List<FunctionMapEntry> functionMap = functionMapGenerator.ParseSourceCode(UnitTestUtils.StreamReaderFromString(sourceCode));
 
 			// Assert
-			Assert.AreEqual(2, functionMap.Count);
+			Assert.Equal(2, functionMap.Count);
 
-			Assert.AreEqual("bar", functionMap[0].Bindings[0].Name);
-			Assert.AreEqual(0, functionMap[0].Bindings[0].SourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(24, functionMap[0].Bindings[0].SourcePosition.ZeroBasedColumnNumber);
-			Assert.AreEqual(0, functionMap[0].StartSourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(0, functionMap[0].EndSourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(29, functionMap[0].StartSourcePosition.ZeroBasedColumnNumber);
-			Assert.AreEqual(37, functionMap[0].EndSourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal("bar", functionMap[0].Bindings[0].Name);
+			Assert.Equal(0, functionMap[0].Bindings[0].SourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(24, functionMap[0].Bindings[0].SourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal(0, functionMap[0].StartSourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(0, functionMap[0].EndSourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(29, functionMap[0].StartSourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal(37, functionMap[0].EndSourcePosition.ZeroBasedColumnNumber);
 
-			Assert.AreEqual("foo", functionMap[1].Bindings[0].Name);
-			Assert.AreEqual(0, functionMap[1].Bindings[0].SourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(9, functionMap[1].Bindings[0].SourcePosition.ZeroBasedColumnNumber);
-			Assert.AreEqual(0, functionMap[1].StartSourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(0, functionMap[1].EndSourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(14, functionMap[1].StartSourcePosition.ZeroBasedColumnNumber);
-			Assert.AreEqual(38, functionMap[1].EndSourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal("foo", functionMap[1].Bindings[0].Name);
+			Assert.Equal(0, functionMap[1].Bindings[0].SourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(9, functionMap[1].Bindings[0].SourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal(0, functionMap[1].StartSourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(0, functionMap[1].EndSourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(14, functionMap[1].StartSourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal(38, functionMap[1].EndSourcePosition.ZeroBasedColumnNumber);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void ParseSourceCode_FunctionAssignedToVariable_FunctionMapEntryGenerated()
 		{
 			// Arrange
@@ -166,18 +166,18 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 			List<FunctionMapEntry> functionMap = functionMapGenerator.ParseSourceCode(UnitTestUtils.StreamReaderFromString(sourceCode));
 
 			// Assert
-			Assert.AreEqual(1, functionMap.Count);
+			Assert.Equal(1, functionMap.Count);
 
-			Assert.AreEqual("foo", functionMap[0].Bindings[0].Name);
-			Assert.AreEqual(0, functionMap[0].Bindings[0].SourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(4, functionMap[0].Bindings[0].SourcePosition.ZeroBasedColumnNumber);
-			Assert.AreEqual(0, functionMap[0].StartSourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(0, functionMap[0].EndSourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(20, functionMap[0].StartSourcePosition.ZeroBasedColumnNumber);
-			Assert.AreEqual(28, functionMap[0].EndSourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal("foo", functionMap[0].Bindings[0].Name);
+			Assert.Equal(0, functionMap[0].Bindings[0].SourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(4, functionMap[0].Bindings[0].SourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal(0, functionMap[0].StartSourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(0, functionMap[0].EndSourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(20, functionMap[0].StartSourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal(28, functionMap[0].EndSourcePosition.ZeroBasedColumnNumber);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void ParseSourceCode_StaticMethod_FunctionMapEntryGenerated()
 		{
 			// Arrange
@@ -188,26 +188,26 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 			List<FunctionMapEntry> functionMap = functionMapGenerator.ParseSourceCode(UnitTestUtils.StreamReaderFromString(sourceCode));
 
 			// Assert
-			Assert.AreEqual(2, functionMap.Count);
+			Assert.Equal(2, functionMap.Count);
 
-			Assert.AreEqual("foo.bar", functionMap[0].Bindings[0].Name);
-			Assert.AreEqual(0, functionMap[0].Bindings[0].SourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(23, functionMap[0].Bindings[0].SourcePosition.ZeroBasedColumnNumber);
-			Assert.AreEqual(0, functionMap[0].StartSourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(0, functionMap[0].EndSourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(44, functionMap[0].StartSourcePosition.ZeroBasedColumnNumber);
-			Assert.AreEqual(54, functionMap[0].EndSourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal("foo.bar", functionMap[0].Bindings[0].Name);
+			Assert.Equal(0, functionMap[0].Bindings[0].SourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(23, functionMap[0].Bindings[0].SourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal(0, functionMap[0].StartSourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(0, functionMap[0].EndSourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(44, functionMap[0].StartSourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal(54, functionMap[0].EndSourcePosition.ZeroBasedColumnNumber);
 
-			Assert.AreEqual("foo", functionMap[1].Bindings[0].Name);
-			Assert.AreEqual(0, functionMap[1].Bindings[0].SourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(4, functionMap[1].Bindings[0].SourcePosition.ZeroBasedColumnNumber);
-			Assert.AreEqual(0, functionMap[1].StartSourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(0, functionMap[1].EndSourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(20, functionMap[1].StartSourcePosition.ZeroBasedColumnNumber);
-			Assert.AreEqual(22, functionMap[1].EndSourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal("foo", functionMap[1].Bindings[0].Name);
+			Assert.Equal(0, functionMap[1].Bindings[0].SourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(4, functionMap[1].Bindings[0].SourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal(0, functionMap[1].StartSourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(0, functionMap[1].EndSourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(20, functionMap[1].StartSourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal(22, functionMap[1].EndSourcePosition.ZeroBasedColumnNumber);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void ParseSourceCode_InstanceMethod_FunctionMapEntryGenerated()
 		{
 			// Arrange
@@ -218,26 +218,26 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 			List<FunctionMapEntry> functionMap = functionMapGenerator.ParseSourceCode(UnitTestUtils.StreamReaderFromString(sourceCode));
 
 			// Assert
-			Assert.AreEqual(2, functionMap.Count);
+			Assert.Equal(2, functionMap.Count);
 
-			Assert.AreEqual("foo.prototype.bar", functionMap[0].Bindings[0].Name);
-			Assert.AreEqual(0, functionMap[0].Bindings[0].SourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(23, functionMap[0].Bindings[0].SourcePosition.ZeroBasedColumnNumber);
-			Assert.AreEqual(0, functionMap[0].StartSourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(0, functionMap[0].EndSourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(55, functionMap[0].StartSourcePosition.ZeroBasedColumnNumber);
-			Assert.AreEqual(65, functionMap[0].EndSourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal("foo.prototype.bar", functionMap[0].Bindings[0].Name);
+			Assert.Equal(0, functionMap[0].Bindings[0].SourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(23, functionMap[0].Bindings[0].SourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal(0, functionMap[0].StartSourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(0, functionMap[0].EndSourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(55, functionMap[0].StartSourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal(65, functionMap[0].EndSourcePosition.ZeroBasedColumnNumber);
 
-			Assert.AreEqual("foo", functionMap[1].Bindings[0].Name);
-			Assert.AreEqual(0, functionMap[1].Bindings[0].SourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(4, functionMap[1].Bindings[0].SourcePosition.ZeroBasedColumnNumber);
-			Assert.AreEqual(0, functionMap[1].StartSourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(0, functionMap[1].EndSourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(20, functionMap[1].StartSourcePosition.ZeroBasedColumnNumber);
-			Assert.AreEqual(22, functionMap[1].EndSourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal("foo", functionMap[1].Bindings[0].Name);
+			Assert.Equal(0, functionMap[1].Bindings[0].SourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(4, functionMap[1].Bindings[0].SourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal(0, functionMap[1].StartSourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(0, functionMap[1].EndSourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(20, functionMap[1].StartSourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal(22, functionMap[1].EndSourcePosition.ZeroBasedColumnNumber);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void ParseSourceCode_InstanceMethodInObjectInitializer_FunctionMapEntryGenerated()
 		{
 			// Arrange
@@ -248,29 +248,29 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 			List<FunctionMapEntry> functionMap = functionMapGenerator.ParseSourceCode(UnitTestUtils.StreamReaderFromString(sourceCode));
 
 			// Assert
-			Assert.AreEqual(2, functionMap.Count);
+			Assert.Equal(2, functionMap.Count);
 
-			Assert.AreEqual("foo.prototype", functionMap[0].Bindings[0].Name);
-			Assert.AreEqual(0, functionMap[0].Bindings[0].SourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(23, functionMap[0].Bindings[0].SourcePosition.ZeroBasedColumnNumber);
-			Assert.AreEqual("bar", functionMap[0].Bindings[1].Name);
-			Assert.AreEqual(0, functionMap[0].Bindings[1].SourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(41, functionMap[0].Bindings[1].SourcePosition.ZeroBasedColumnNumber);
-			Assert.AreEqual(0, functionMap[0].StartSourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(0, functionMap[0].EndSourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(58, functionMap[0].StartSourcePosition.ZeroBasedColumnNumber);
-			Assert.AreEqual(68, functionMap[0].EndSourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal("foo.prototype", functionMap[0].Bindings[0].Name);
+			Assert.Equal(0, functionMap[0].Bindings[0].SourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(23, functionMap[0].Bindings[0].SourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal("bar", functionMap[0].Bindings[1].Name);
+			Assert.Equal(0, functionMap[0].Bindings[1].SourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(41, functionMap[0].Bindings[1].SourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal(0, functionMap[0].StartSourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(0, functionMap[0].EndSourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(58, functionMap[0].StartSourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal(68, functionMap[0].EndSourcePosition.ZeroBasedColumnNumber);
 
-			Assert.AreEqual("foo", functionMap[1].Bindings[0].Name);
-			Assert.AreEqual(0, functionMap[1].Bindings[0].SourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(4, functionMap[1].Bindings[0].SourcePosition.ZeroBasedColumnNumber);
-			Assert.AreEqual(0, functionMap[1].StartSourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(0, functionMap[1].EndSourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(20, functionMap[1].StartSourcePosition.ZeroBasedColumnNumber);
-			Assert.AreEqual(22, functionMap[1].EndSourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal("foo", functionMap[1].Bindings[0].Name);
+			Assert.Equal(0, functionMap[1].Bindings[0].SourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(4, functionMap[1].Bindings[0].SourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal(0, functionMap[1].StartSourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(0, functionMap[1].EndSourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(20, functionMap[1].StartSourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal(22, functionMap[1].EndSourcePosition.ZeroBasedColumnNumber);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void ParseSourceCode_FunctionAssignedToVariableAndHasName_FunctionMapEntryGeneratedForVariableName()
 		{
 			// Arrange
@@ -281,18 +281,18 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 			List<FunctionMapEntry> functionMap = functionMapGenerator.ParseSourceCode(UnitTestUtils.StreamReaderFromString(sourceCode));
 
 			// Assert
-			Assert.AreEqual(1, functionMap.Count);
+			Assert.Equal(1, functionMap.Count);
 
-			Assert.AreEqual("foo", functionMap[0].Bindings[0].Name);
-			Assert.AreEqual(0, functionMap[0].Bindings[0].SourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(4, functionMap[0].Bindings[0].SourcePosition.ZeroBasedColumnNumber);
-			Assert.AreEqual(0, functionMap[0].StartSourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(0, functionMap[0].EndSourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(39, functionMap[0].StartSourcePosition.ZeroBasedColumnNumber);
-			Assert.AreEqual(49, functionMap[0].EndSourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal("foo", functionMap[0].Bindings[0].Name);
+			Assert.Equal(0, functionMap[0].Bindings[0].SourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(4, functionMap[0].Bindings[0].SourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal(0, functionMap[0].StartSourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(0, functionMap[0].EndSourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(39, functionMap[0].StartSourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal(49, functionMap[0].EndSourcePosition.ZeroBasedColumnNumber);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void ParseSourceCode_StaticMethodAndFunctionHasName_FunctionMapEntryGeneratedForPropertyName()
 		{
 			// Arrange
@@ -303,26 +303,26 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 			List<FunctionMapEntry> functionMap = functionMapGenerator.ParseSourceCode(UnitTestUtils.StreamReaderFromString(sourceCode));
 
 			// Assert
-			Assert.AreEqual(2, functionMap.Count);
+			Assert.Equal(2, functionMap.Count);
 
-			Assert.AreEqual("foo.bar", functionMap[0].Bindings[0].Name);
-			Assert.AreEqual(0, functionMap[0].Bindings[0].SourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(23, functionMap[0].Bindings[0].SourcePosition.ZeroBasedColumnNumber);
-			Assert.AreEqual(0, functionMap[0].StartSourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(0, functionMap[0].EndSourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(63, functionMap[0].StartSourcePosition.ZeroBasedColumnNumber);
-			Assert.AreEqual(73, functionMap[0].EndSourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal("foo.bar", functionMap[0].Bindings[0].Name);
+			Assert.Equal(0, functionMap[0].Bindings[0].SourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(23, functionMap[0].Bindings[0].SourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal(0, functionMap[0].StartSourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(0, functionMap[0].EndSourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(63, functionMap[0].StartSourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal(73, functionMap[0].EndSourcePosition.ZeroBasedColumnNumber);
 
-			Assert.AreEqual("foo", functionMap[1].Bindings[0].Name);
-			Assert.AreEqual(0, functionMap[1].Bindings[0].SourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(4, functionMap[1].Bindings[0].SourcePosition.ZeroBasedColumnNumber);
-			Assert.AreEqual(0, functionMap[1].StartSourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(0, functionMap[1].EndSourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(20, functionMap[1].StartSourcePosition.ZeroBasedColumnNumber);
-			Assert.AreEqual(22, functionMap[1].EndSourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal("foo", functionMap[1].Bindings[0].Name);
+			Assert.Equal(0, functionMap[1].Bindings[0].SourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(4, functionMap[1].Bindings[0].SourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal(0, functionMap[1].StartSourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(0, functionMap[1].EndSourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(20, functionMap[1].StartSourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal(22, functionMap[1].EndSourcePosition.ZeroBasedColumnNumber);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void ParseSourceCode_InstanceMethodAndFunctionHasName_FunctionMapEntryGeneratedForObjectPrototype()
 		{
 			// Arrange
@@ -333,26 +333,26 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 			List<FunctionMapEntry> functionMap = functionMapGenerator.ParseSourceCode(UnitTestUtils.StreamReaderFromString(sourceCode));
 
 			// Assert
-			Assert.AreEqual(2, functionMap.Count);
+			Assert.Equal(2, functionMap.Count);
 
-			Assert.AreEqual("foo.prototype.bar", functionMap[0].Bindings[0].Name);
-			Assert.AreEqual(0, functionMap[0].Bindings[0].SourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(23, functionMap[0].Bindings[0].SourcePosition.ZeroBasedColumnNumber);
-			Assert.AreEqual(0, functionMap[0].StartSourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(0, functionMap[0].EndSourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(73, functionMap[0].StartSourcePosition.ZeroBasedColumnNumber);
-			Assert.AreEqual(83, functionMap[0].EndSourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal("foo.prototype.bar", functionMap[0].Bindings[0].Name);
+			Assert.Equal(0, functionMap[0].Bindings[0].SourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(23, functionMap[0].Bindings[0].SourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal(0, functionMap[0].StartSourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(0, functionMap[0].EndSourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(73, functionMap[0].StartSourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal(83, functionMap[0].EndSourcePosition.ZeroBasedColumnNumber);
 
-			Assert.AreEqual("foo", functionMap[1].Bindings[0].Name);
-			Assert.AreEqual(0, functionMap[1].Bindings[0].SourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(4, functionMap[1].Bindings[0].SourcePosition.ZeroBasedColumnNumber);
-			Assert.AreEqual(0, functionMap[1].StartSourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(0, functionMap[1].EndSourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(20, functionMap[1].StartSourcePosition.ZeroBasedColumnNumber);
-			Assert.AreEqual(22, functionMap[1].EndSourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal("foo", functionMap[1].Bindings[0].Name);
+			Assert.Equal(0, functionMap[1].Bindings[0].SourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(4, functionMap[1].Bindings[0].SourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal(0, functionMap[1].StartSourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(0, functionMap[1].EndSourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(20, functionMap[1].StartSourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal(22, functionMap[1].EndSourcePosition.ZeroBasedColumnNumber);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void ParseSourceCode_InstanceMethodWithObjectInitializerAndFunctionHasName_FunctionMapEntryGeneratedForObjectPrototype()
 		{
 			// Arrange
@@ -363,30 +363,29 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 			List<FunctionMapEntry> functionMap = functionMapGenerator.ParseSourceCode(UnitTestUtils.StreamReaderFromString(sourceCode));
 
 			// Assert
-			Assert.AreEqual(2, functionMap.Count);
+			Assert.Equal(2, functionMap.Count);
 
-			Assert.AreEqual("foo.prototype", functionMap[0].Bindings[0].Name);
-			Assert.AreEqual(0, functionMap[0].Bindings[0].SourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(23, functionMap[0].Bindings[0].SourcePosition.ZeroBasedColumnNumber);
-			Assert.AreEqual("bar", functionMap[0].Bindings[1].Name);
-			Assert.AreEqual(0, functionMap[0].Bindings[1].SourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(41, functionMap[0].Bindings[1].SourcePosition.ZeroBasedColumnNumber);
-			Assert.AreEqual(0, functionMap[0].StartSourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(0, functionMap[0].EndSourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(76, functionMap[0].StartSourcePosition.ZeroBasedColumnNumber);
-			Assert.AreEqual(86, functionMap[0].EndSourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal("foo.prototype", functionMap[0].Bindings[0].Name);
+			Assert.Equal(0, functionMap[0].Bindings[0].SourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(23, functionMap[0].Bindings[0].SourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal("bar", functionMap[0].Bindings[1].Name);
+			Assert.Equal(0, functionMap[0].Bindings[1].SourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(41, functionMap[0].Bindings[1].SourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal(0, functionMap[0].StartSourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(0, functionMap[0].EndSourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(76, functionMap[0].StartSourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal(86, functionMap[0].EndSourcePosition.ZeroBasedColumnNumber);
 
-			Assert.AreEqual("foo", functionMap[1].Bindings[0].Name);
-			Assert.AreEqual(0, functionMap[1].Bindings[0].SourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(4, functionMap[1].Bindings[0].SourcePosition.ZeroBasedColumnNumber);
-			Assert.AreEqual(0, functionMap[1].StartSourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(0, functionMap[1].EndSourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(20, functionMap[1].StartSourcePosition.ZeroBasedColumnNumber);
-			Assert.AreEqual(22, functionMap[1].EndSourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal("foo", functionMap[1].Bindings[0].Name);
+			Assert.Equal(0, functionMap[1].Bindings[0].SourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(4, functionMap[1].Bindings[0].SourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal(0, functionMap[1].StartSourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(0, functionMap[1].EndSourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(20, functionMap[1].StartSourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal(22, functionMap[1].EndSourcePosition.ZeroBasedColumnNumber);
 		}
 
-		[TestMethod]
-		[ExpectedException(typeof(ArgumentNullException))]
+		[Fact]
 		public void GetDeminifiedMethodNameFromSourceMap_NullFunctionMapEntry_ThrowsException()
 		{
 			// Arrange
@@ -394,11 +393,10 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 			SourceMap sourceMap = MockRepository.GenerateStub<SourceMap>();
 
 			// Act
-			FunctionMapGenerator.GetDeminifiedMethodNameFromSourceMap(functionMapEntry, sourceMap);
+			Assert.Throws<ArgumentNullException>( ()=> FunctionMapGenerator.GetDeminifiedMethodNameFromSourceMap(functionMapEntry, sourceMap));
 		}
 
-		[TestMethod]
-		[ExpectedException(typeof(ArgumentNullException))]
+		[Fact]
 		public void GetDeminifiedMethodNameFromSourceMap_NullSourceMap_ThrowsException()
 		{
 			// Arrange
@@ -406,10 +404,10 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 			SourceMap sourceMap = null;
 
 			// Act
-			FunctionMapGenerator.GetDeminifiedMethodNameFromSourceMap(functionMapEntry, sourceMap);
+			Assert.Throws<ArgumentNullException>( ()=> FunctionMapGenerator.GetDeminifiedMethodNameFromSourceMap(functionMapEntry, sourceMap));
 		}
 
-		[TestMethod]
+		[Fact]
 		public void GetDeminifiedMethodNameFromSourceMap_NoBinding_ReturnNullMethodName()
 		{
 			// Arrange
@@ -420,11 +418,11 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 			string result = FunctionMapGenerator.GetDeminifiedMethodNameFromSourceMap(functionMapEntry, sourceMap);
 
 			// Assert
-			Assert.IsNull(result);
+			Assert.Null(result);
 			sourceMap.VerifyAllExpectations();
 		}
 
-		[TestMethod]
+		[Fact]
 		public void GetDeminifiedMethodNameFromSourceMap_HasSingleBindingNoMatchingMapping_ReturnNullMethodName()
 		{
 			// Arrange
@@ -447,11 +445,11 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 			string result = FunctionMapGenerator.GetDeminifiedMethodNameFromSourceMap(functionMapEntry, sourceMap);
 
 			// Assert
-			Assert.IsNull(result);
+			Assert.Null(result);
 			sourceMap.VerifyAllExpectations();
 		}
 
-		[TestMethod]
+		[Fact]
 		public void GetDeminifiedMethodNameFromSourceMap_HasSingleBindingMatchingMapping_ReturnsMethodName()
 		{
 			// Arrange
@@ -481,11 +479,11 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 			string result = FunctionMapGenerator.GetDeminifiedMethodNameFromSourceMap(functionMapEntry, sourceMap);
 
 			// Assert
-			Assert.AreEqual("foo", result);
+			Assert.Equal("foo", result);
 			sourceMap.VerifyAllExpectations();
 		}
 
-		[TestMethod]
+		[Fact]
 		public void GetDeminifiedMethodNameFromSourceMap_MatchingMappingMultipleBindingsMissingPrototypeMapping_ReturnsMethodName()
 		{
 			// Arrange
@@ -525,11 +523,11 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 			string result = FunctionMapGenerator.GetDeminifiedMethodNameFromSourceMap(functionMapEntry, sourceMap);
 
 			// Assert
-			Assert.AreEqual("baz", result);
+			Assert.Equal("baz", result);
 			sourceMap.VerifyAllExpectations();
 		}
 
-		[TestMethod]
+		[Fact]
 		public void GetDeminifiedMethodNameFromSourceMap_MatchingMappingMultipleBindings_ReturnsMethodNameWithFullBinding()
 		{
 			// Arrange
@@ -572,7 +570,7 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 			string result = FunctionMapGenerator.GetDeminifiedMethodNameFromSourceMap(functionMapEntry, sourceMap);
 
 			// Assert
-			Assert.AreEqual("bar.baz", result);
+			Assert.Equal("bar.baz", result);
 			sourceMap.VerifyAllExpectations();
 		}
 	}

--- a/tests/SourcemapToolkit.CallstackDeminifier.UnitTests/KeyValueCacheUnitTests.cs
+++ b/tests/SourcemapToolkit.CallstackDeminifier.UnitTests/KeyValueCacheUnitTests.cs
@@ -1,13 +1,13 @@
 ﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 using Rhino.Mocks;
 
 namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 {
-	[TestClass]
+
 	public class KeyValueCacheUnitTests
 	{
-		[TestMethod]
+		[Fact]
 		public void GetValue_KeyNotInCache_CallValueGetter()
 		{
 			// Arrange
@@ -19,11 +19,11 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 			string result = keyValueCache.GetValue("bar");
 
 			// Assert
-			Assert.AreEqual("foo", result);
+			Assert.Equal("foo", result);
 
 		}
 
-		[TestMethod]
+		[Fact]
 		public void GetValue_CallGetTwice_OnlyCallValueGetterOnce()
 		{
 			// Arrange
@@ -36,11 +36,11 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 			string result = keyValueCache.GetValue("bar");
 
 			// Assert
-			Assert.AreEqual("foo", result);
+			Assert.Equal("foo", result);
 			valueGetter.VerifyAllExpectations();
 		}
 
-		[TestMethod]
+		[Fact]
 		public void GetValue_CallGetTwiceValueGetterReturnsNull_CallGetterTwice()
 		{
 			// Arrange
@@ -53,11 +53,11 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 			string result = keyValueCache.GetValue("bar");
 
 			// Assert
-			Assert.AreEqual(null, result);
+			Assert.Equal(null, result);
 			valueGetter.VerifyAllExpectations();
 		}
 
-		[TestMethod]
+		[Fact]
 		public void GetValue_CallGetMultipleTimesFirstGetterReturnsNull_CacheFirstNonNullValue()
 		{
 			// Arrange
@@ -72,7 +72,7 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 			string result = keyValueCache.GetValue("bar");
 
 			// Assert
-			Assert.AreEqual("foo", result);
+			Assert.Equal("foo", result);
 			valueGetter.VerifyAllExpectations();
 		}
 	}

--- a/tests/SourcemapToolkit.CallstackDeminifier.UnitTests/SourcemapToolkit.CallstackDeminifier.UnitTests.csproj
+++ b/tests/SourcemapToolkit.CallstackDeminifier.UnitTests/SourcemapToolkit.CallstackDeminifier.UnitTests.csproj
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\xunit.core.2.4.1\build\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.4.1\build\xunit.core.props')" />
+  <Import Project="..\..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -41,11 +43,39 @@
     <AssemblyOriginatorKeyFile>..\..\SourceMapToolkit.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.UnitTestFramework.Extensions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=5bf63060baa03a11">
+      <HintPath>..\..\packages\Microsoft.UnitTestFramework.Extensions.2.0.0\lib\net45\Microsoft.UnitTestFramework.Extensions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\..\packages\MSTest.TestFramework.1.1.17\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\..\packages\MSTest.TestFramework.1.1.17\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Rhino.Mocks, Version=3.6.0.0, Culture=neutral, PublicKeyToken=0b3305902db7183f, processorArchitecture=MSIL">
       <HintPath>..\..\packages\RhinoMocks.3.6.1\lib\net\Rhino.Mocks.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
+      <HintPath>..\..\packages\xunit.abstractions.2.0.3\lib\net35\xunit.abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.assert, Version=2.4.1.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
+      <HintPath>..\..\packages\xunit.assert.2.4.1\lib\netstandard1.1\xunit.assert.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.core, Version=2.4.1.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
+      <HintPath>..\..\packages\xunit.extensibility.core.2.4.1\lib\net452\xunit.core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.execution.desktop, Version=2.4.1.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
+      <HintPath>..\..\packages\xunit.extensibility.execution.2.4.1\lib\net452\xunit.execution.desktop.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
   </ItemGroup>
   <Choose>
     <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
@@ -89,6 +119,9 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\..\packages\xunit.analyzers.0.10.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
+  </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
       <ItemGroup>
@@ -109,6 +142,15 @@
   </Choose>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105.The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.core.2.4.1\build\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.4.1\build\xunit.core.props'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.core.2.4.1\build\xunit.core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.4.1\build\xunit.core.targets'))" />
+  </Target>
+  <Import Project="..\..\packages\xunit.core.2.4.1\build\xunit.core.targets" Condition="Exists('..\..\packages\xunit.core.2.4.1\build\xunit.core.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/tests/SourcemapToolkit.CallstackDeminifier.UnitTests/StackFrameDeminifierUnitTests.cs
+++ b/tests/SourcemapToolkit.CallstackDeminifier.UnitTests/StackFrameDeminifierUnitTests.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 using Rhino.Mocks;
 using SourcemapToolkit.SourcemapParser;
 
+[assembly: CollectionBehavior(DisableTestParallelization = true)]
 namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 {
-	[TestClass]
+
 	public class StackFrameDeminifierUnitTests
 	{ 
 		private IStackFrameDeminifier GetStackFrameDeminifierWithMockDependencies(ISourceMapStore sourceMapStore = null, IFunctionMapStore functionMapStore = null, IFunctionMapConsumer functionMapConsumer = null, bool useSimpleStackFrameDeminier = false)
@@ -36,8 +37,7 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 			}
 		}
 
-		[TestMethod]
-		[ExpectedException(typeof(ArgumentNullException))]
+		[Fact]
 		public void DeminifyStackFrame_NullInputStackFrame_ThrowsException()
 		{
 			// Arrange
@@ -45,10 +45,10 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 			StackFrame stackFrame = null;
 
 			// Act
-			StackFrameDeminificationResult stackFrameDeminification = stackFrameDeminifier.DeminifyStackFrame(stackFrame);
+			Assert.Throws<ArgumentNullException>( ()=> stackFrameDeminifier.DeminifyStackFrame(stackFrame));
 		}
 
-		[TestMethod]
+		[Fact]
 		public void DeminifyStackFrame_StackFrameNullProperties_DoesNotThrowException()
 		{
 			// Arrange
@@ -59,12 +59,12 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 			StackFrameDeminificationResult stackFrameDeminification = stackFrameDeminifier.DeminifyStackFrame(stackFrame);
 
 			// Assert
-			Assert.IsNull(stackFrameDeminification.DeminifiedStackFrame.MethodName);
-			Assert.IsNull(stackFrameDeminification.DeminifiedStackFrame.SourcePosition);
-			Assert.IsNull(stackFrameDeminification.DeminifiedStackFrame.FilePath);
+			Assert.Null(stackFrameDeminification.DeminifiedStackFrame.MethodName);
+			Assert.Null(stackFrameDeminification.DeminifiedStackFrame.SourcePosition);
+			Assert.Null(stackFrameDeminification.DeminifiedStackFrame.FilePath);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void SimpleStackFrameDeminierDeminifyStackFrame_FunctionMapReturnsNull_NoFunctionMapDeminificationError()
 		{
 			// Arrange
@@ -80,13 +80,13 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 			StackFrameDeminificationResult stackFrameDeminification = stackFrameDeminifier.DeminifyStackFrame(stackFrame);
 
 			// Assert
-			Assert.AreEqual(DeminificationError.NoSourceCodeProvided, stackFrameDeminification.DeminificationError);
-			Assert.IsNull(stackFrameDeminification.DeminifiedStackFrame.MethodName);
-			Assert.IsNull(stackFrameDeminification.DeminifiedStackFrame.SourcePosition);
-			Assert.IsNull(stackFrameDeminification.DeminifiedStackFrame.FilePath);
+			Assert.Equal(DeminificationError.NoSourceCodeProvided, stackFrameDeminification.DeminificationError);
+			Assert.Null(stackFrameDeminification.DeminifiedStackFrame.MethodName);
+			Assert.Null(stackFrameDeminification.DeminifiedStackFrame.SourcePosition);
+			Assert.Null(stackFrameDeminification.DeminifiedStackFrame.FilePath);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void SimpleStackFrameDeminierDeminifyStackFrame_GetWRappingFunctionForSourceLocationReturnsNull_NoWrapingFunctionDeminificationError()
 		{
 			// Arrange
@@ -105,13 +105,13 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 			StackFrameDeminificationResult stackFrameDeminification = stackFrameDeminifier.DeminifyStackFrame(stackFrame);
 
 			// Assert
-			Assert.AreEqual(DeminificationError.NoWrapingFunctionFound, stackFrameDeminification.DeminificationError);
-			Assert.IsNull(stackFrameDeminification.DeminifiedStackFrame.MethodName);
-			Assert.IsNull(stackFrameDeminification.DeminifiedStackFrame.SourcePosition);
-			Assert.IsNull(stackFrameDeminification.DeminifiedStackFrame.FilePath);
+			Assert.Equal(DeminificationError.NoWrapingFunctionFound, stackFrameDeminification.DeminificationError);
+			Assert.Null(stackFrameDeminification.DeminifiedStackFrame.MethodName);
+			Assert.Null(stackFrameDeminification.DeminifiedStackFrame.SourcePosition);
+			Assert.Null(stackFrameDeminification.DeminifiedStackFrame.FilePath);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void SimpleStackFrameDeminierDeminifyStackFrame_WrapingFunctionFound_NoDeminificationError()
 		{
 			// Arrange
@@ -131,14 +131,14 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 			StackFrameDeminificationResult stackFrameDeminification = stackFrameDeminifier.DeminifyStackFrame(stackFrame);
 
 			// Assert
-			Assert.AreEqual(DeminificationError.None, stackFrameDeminification.DeminificationError);
-			Assert.AreEqual(wrapingFunctionMapEntry.DeminfifiedMethodName, stackFrameDeminification.DeminifiedStackFrame.MethodName);
-			Assert.IsNull(stackFrameDeminification.DeminifiedStackFrame.SourcePosition);
-			Assert.IsNull(stackFrameDeminification.DeminifiedStackFrame.FilePath);
+			Assert.Equal(DeminificationError.None, stackFrameDeminification.DeminificationError);
+			Assert.Equal(wrapingFunctionMapEntry.DeminfifiedMethodName, stackFrameDeminification.DeminifiedStackFrame.MethodName);
+			Assert.Null(stackFrameDeminification.DeminifiedStackFrame.SourcePosition);
+			Assert.Null(stackFrameDeminification.DeminifiedStackFrame.FilePath);
 		}
 
 
-		[TestMethod]
+		[Fact]
 		public void StackFrameDeminierDeminifyStackFrame_SourceMapProviderReturnsNull_NoSourcemapProvidedError()
 		{
 			// Arrange
@@ -158,13 +158,13 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 			StackFrameDeminificationResult stackFrameDeminification = stackFrameDeminifier.DeminifyStackFrame(stackFrame);
 
 			// Assert
-			Assert.AreEqual(DeminificationError.NoSourceMap, stackFrameDeminification.DeminificationError);
-			Assert.AreEqual(wrapingFunctionMapEntry.DeminfifiedMethodName, stackFrameDeminification.DeminifiedStackFrame.MethodName);
-			Assert.IsNull(stackFrameDeminification.DeminifiedStackFrame.SourcePosition);
-			Assert.IsNull(stackFrameDeminification.DeminifiedStackFrame.FilePath);
+			Assert.Equal(DeminificationError.NoSourceMap, stackFrameDeminification.DeminificationError);
+			Assert.Equal(wrapingFunctionMapEntry.DeminfifiedMethodName, stackFrameDeminification.DeminifiedStackFrame.MethodName);
+			Assert.Null(stackFrameDeminification.DeminifiedStackFrame.SourcePosition);
+			Assert.Null(stackFrameDeminification.DeminifiedStackFrame.FilePath);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void StackFrameDeminierDeminifyStackFrame_SourceMapParsingNull_SourceMapFailedToParseError()
 		{
 			// Arrange
@@ -186,13 +186,13 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 			StackFrameDeminificationResult stackFrameDeminification = stackFrameDeminifier.DeminifyStackFrame(stackFrame);
 
 			// Assert
-			Assert.AreEqual(DeminificationError.SourceMapFailedToParse, stackFrameDeminification.DeminificationError);
-			Assert.AreEqual(wrapingFunctionMapEntry.DeminfifiedMethodName, stackFrameDeminification.DeminifiedStackFrame.MethodName);
-			Assert.IsNull(stackFrameDeminification.DeminifiedStackFrame.SourcePosition);
-			Assert.IsNull(stackFrameDeminification.DeminifiedStackFrame.FilePath);
+			Assert.Equal(DeminificationError.SourceMapFailedToParse, stackFrameDeminification.DeminificationError);
+			Assert.Equal(wrapingFunctionMapEntry.DeminfifiedMethodName, stackFrameDeminification.DeminifiedStackFrame.MethodName);
+			Assert.Null(stackFrameDeminification.DeminifiedStackFrame.SourcePosition);
+			Assert.Null(stackFrameDeminification.DeminifiedStackFrame.FilePath);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void StackFrameDeminierDeminifyStackFrame_SourceMapGeneratedMappingEntryNull_NoMatchingMapingInSourceMapError()
 		{
 			// Arrange
@@ -216,10 +216,10 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 			StackFrameDeminificationResult stackFrameDeminification = stackFrameDeminifier.DeminifyStackFrame(stackFrame);
 
 			// Assert
-			Assert.AreEqual(DeminificationError.NoMatchingMapingInSourceMap, stackFrameDeminification.DeminificationError);
-			Assert.AreEqual(wrapingFunctionMapEntry.DeminfifiedMethodName, stackFrameDeminification.DeminifiedStackFrame.MethodName);
-			Assert.IsNull(stackFrameDeminification.DeminifiedStackFrame.SourcePosition);
-			Assert.IsNull(stackFrameDeminification.DeminifiedStackFrame.FilePath);
+			Assert.Equal(DeminificationError.NoMatchingMapingInSourceMap, stackFrameDeminification.DeminificationError);
+			Assert.Equal(wrapingFunctionMapEntry.DeminfifiedMethodName, stackFrameDeminification.DeminifiedStackFrame.MethodName);
+			Assert.Null(stackFrameDeminification.DeminifiedStackFrame.SourcePosition);
+			Assert.Null(stackFrameDeminification.DeminifiedStackFrame.FilePath);
 		}
 
 	}

--- a/tests/SourcemapToolkit.CallstackDeminifier.UnitTests/StackTraceDeminifierClosureEndToEndTests.cs
+++ b/tests/SourcemapToolkit.CallstackDeminifier.UnitTests/StackTraceDeminifierClosureEndToEndTests.cs
@@ -1,11 +1,11 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Xunit;
 using Rhino.Mocks;
 using SourcemapToolkit.SourcemapParser.UnitTests;
 
 namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 {
 
-	[TestClass]
+
 	public class StackTraceDeminifierClosureEndToEndTests
 	{
 		private const string GeneratedCodeString = "function a(){}window.foo=a;a.prototype={b:function(){return a.a(void 0)}};a.a=function(b){return b.length};function c(){return(new a).b()}window.foo.bar=a.b;window.foo.bar2=a.a;window.bar=c;window.onerror=function(b,e,f,g,d){d?document.getElementById(\"callstackdisplay\").innerText=d.stack:window.event.error&&(document.getElementById(\"callstackdisplay\").innerText=window.event.error.stack)};window.onload=function(){document.getElementById(\"crashbutton\").addEventListener(\"click\",function(){console.log(c())})};";
@@ -25,15 +25,15 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 
 		private void ValidateDeminifyStackTraceResults(DeminifyStackTraceResult results)
 		{
-			Assert.AreEqual(4, results.DeminifiedStackFrameResults.Count);
-			Assert.AreEqual(DeminificationError.None, results.DeminifiedStackFrameResults[0].DeminificationError);
-			Assert.AreEqual("mynamespace.objectWithMethods.propertyMethodLevel2", results.DeminifiedStackFrameResults[0].DeminifiedStackFrame.MethodName);
-			Assert.AreEqual("mynamespace.objectWithMethods.prototypeMethodLevel1", results.DeminifiedStackFrameResults[1].DeminifiedStackFrame.MethodName);
-			Assert.AreEqual("GlobalFunction", results.DeminifiedStackFrameResults[2].DeminifiedStackFrame.MethodName);
-			Assert.AreEqual("window", results.DeminifiedStackFrameResults[3].DeminifiedStackFrame.MethodName);
+			Assert.Equal(4, results.DeminifiedStackFrameResults.Count);
+			Assert.Equal(DeminificationError.None, results.DeminifiedStackFrameResults[0].DeminificationError);
+			Assert.Equal("mynamespace.objectWithMethods.propertyMethodLevel2", results.DeminifiedStackFrameResults[0].DeminifiedStackFrame.MethodName);
+			Assert.Equal("mynamespace.objectWithMethods.prototypeMethodLevel1", results.DeminifiedStackFrameResults[1].DeminifiedStackFrame.MethodName);
+			Assert.Equal("GlobalFunction", results.DeminifiedStackFrameResults[2].DeminifiedStackFrame.MethodName);
+			Assert.Equal("window", results.DeminifiedStackFrameResults[3].DeminifiedStackFrame.MethodName);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void DeminifyClosureStackTrace_ChromeStackTraceString_CorrectDeminificationWhenPossible()
 		{
 			// Arrange
@@ -51,7 +51,7 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 			ValidateDeminifyStackTraceResults(results);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void DeminifyClosureStackTrace_FireFoxStackTraceString_CorrectDeminificationWhenPossible()
 		{
 			// Arrange
@@ -68,7 +68,7 @@ window.onload/<@http://localhost:11323/closurecrashcauser.minified.js:1:504";
 			ValidateDeminifyStackTraceResults(results);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void DeminifyClosureStackTrace_IE11StackTraceString_CorrectDeminificationWhenPossible()
 		{
 			// Arrange
@@ -86,7 +86,7 @@ window.onload/<@http://localhost:11323/closurecrashcauser.minified.js:1:504";
 			ValidateDeminifyStackTraceResults(results);
 		}
 
-        [TestMethod]
+        [Fact]
         public void DeminifyClosureStackTrace_EdgeStackTraceString_CorrectDeminificationWhenPossible()
         {
             // Arrange

--- a/tests/SourcemapToolkit.CallstackDeminifier.UnitTests/StackTraceDeminifierEndToEndTests.cs
+++ b/tests/SourcemapToolkit.CallstackDeminifier.UnitTests/StackTraceDeminifierEndToEndTests.cs
@@ -1,10 +1,10 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Xunit;
 using Rhino.Mocks;
 using SourcemapToolkit.SourcemapParser.UnitTests;
 
 namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 {
-	[TestClass]
+
 	public class StackTraceDeminifierEndToEndTests
 	{
 		private const string GeneratedCodeString = "function causeCrash(){function n(){var n=16;n+=2;t(n)}function t(n){n=n+2;i(n)}function i(n){(function(){var t;console.log(t.length+n)})()}window.onerror=function(n,t,i,r,u){u?document.getElementById(\"callstackdisplay\").innerText=u.stack:window.event.error&&(document.getElementById(\"callstackdisplay\").innerText=window.event.error.stack)};n()}window.onload=function(){document.getElementById(\"crashbutton\").addEventListener(\"click\",function(){causeCrash()})};";
@@ -24,17 +24,17 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 
 		private static void ValidateDeminifyStackTraceResults(DeminifyStackTraceResult results)
 		{
-			Assert.AreEqual(6, results.DeminifiedStackFrameResults.Count);
-			Assert.AreEqual(DeminificationError.None, results.DeminifiedStackFrameResults[0].DeminificationError);
-            Assert.AreEqual("level3", results.DeminifiedStackFrameResults[0].DeminifiedStackFrame.MethodName);
-            Assert.AreEqual("level3", results.DeminifiedStackFrameResults[1].DeminifiedStackFrame.MethodName);
-			Assert.AreEqual("level2", results.DeminifiedStackFrameResults[2].DeminifiedStackFrame.MethodName);
-			Assert.AreEqual("level1", results.DeminifiedStackFrameResults[3].DeminifiedStackFrame.MethodName);
-			Assert.AreEqual("causeCrash", results.DeminifiedStackFrameResults[4].DeminifiedStackFrame.MethodName);
-			Assert.AreEqual("window", results.DeminifiedStackFrameResults[5].DeminifiedStackFrame.MethodName);
+			Assert.Equal(6, results.DeminifiedStackFrameResults.Count);
+			Assert.Equal(DeminificationError.None, results.DeminifiedStackFrameResults[0].DeminificationError);
+            Assert.Equal("level3", results.DeminifiedStackFrameResults[0].DeminifiedStackFrame.MethodName);
+            Assert.Equal("level3", results.DeminifiedStackFrameResults[1].DeminifiedStackFrame.MethodName);
+			Assert.Equal("level2", results.DeminifiedStackFrameResults[2].DeminifiedStackFrame.MethodName);
+			Assert.Equal("level1", results.DeminifiedStackFrameResults[3].DeminifiedStackFrame.MethodName);
+			Assert.Equal("causeCrash", results.DeminifiedStackFrameResults[4].DeminifiedStackFrame.MethodName);
+			Assert.Equal("window", results.DeminifiedStackFrameResults[5].DeminifiedStackFrame.MethodName);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void DeminifyStackTrace_ChromeStackTraceString_CorrectDeminificationWhenPossible()
 		{
 			// Arrange
@@ -54,7 +54,7 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 			ValidateDeminifyStackTraceResults(results);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void DeminifyStackTrace_FireFoxStackTraceString_CorrectDeminificationWhenPossible()
 		{
 			// Arrange
@@ -73,7 +73,7 @@ window.onload/<@http://localhost:11323/crashcauser.min.js:1:445";
 			ValidateDeminifyStackTraceResults(results);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void DeminifyStackTrace_IE11StackTraceString_CorrectDeminificationWhenPossible()
 		{
 			// Arrange
@@ -93,7 +93,7 @@ window.onload/<@http://localhost:11323/crashcauser.min.js:1:445";
 			ValidateDeminifyStackTraceResults(results);
 		}
 
-        [TestMethod]
+        [Fact]
         public void DeminifyStackTrace_EdgeStackTraceString_CorrectDeminificationWhenPossible()
         {
             // Arrange

--- a/tests/SourcemapToolkit.CallstackDeminifier.UnitTests/StackTraceDeminifierUnitTests.cs
+++ b/tests/SourcemapToolkit.CallstackDeminifier.UnitTests/StackTraceDeminifierUnitTests.cs
@@ -1,13 +1,13 @@
 ﻿using System.Collections.Generic;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 using Rhino.Mocks;
 
 namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 {
-	[TestClass]
+
 	public class StackTraceDeminifierUnitTests
 	{
-		[TestMethod]
+		[Fact]
 		public void DeminifyStackTrace_UnableToParseStackTraceString_ReturnsEmptyList()
 		{
 			// Arrange
@@ -23,10 +23,10 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 			DeminifyStackTraceResult result = stackTraceDeminifier.DeminifyStackTrace(stackTraceString);
 
 			// Assert
-			Assert.AreEqual(0, result.DeminifiedStackFrameResults.Count);
+			Assert.Equal(0, result.DeminifiedStackFrameResults.Count);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void DeminifyStackTrace_UnableToDeminifyStackTrace_ResultContainsNullDeminifiedFrame()
 		{
 			// Arrange
@@ -44,12 +44,12 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 			DeminifyStackTraceResult result = stackTraceDeminifier.DeminifyStackTrace(stackTraceString);
 
 			// Assert
-			Assert.AreEqual(1, result.DeminifiedStackFrameResults.Count);
-			Assert.AreEqual(minifiedStackFrames[0], result.MinifiedStackFrames[0]);
-			Assert.IsNull(result.DeminifiedStackFrameResults[0]);
+			Assert.Equal(1, result.DeminifiedStackFrameResults.Count);
+			Assert.Equal(minifiedStackFrames[0], result.MinifiedStackFrames[0]);
+			Assert.Null(result.DeminifiedStackFrameResults[0]);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void DeminifyStackTrace_AbleToDeminifyStackTrace_ResultContainsDeminifiedFrame()
 		{
 			// Arrange
@@ -68,9 +68,9 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 			DeminifyStackTraceResult result = stackTraceDeminifier.DeminifyStackTrace(stackTraceString);
 
 			// Assert
-			Assert.AreEqual(1, result.DeminifiedStackFrameResults.Count);
-			Assert.AreEqual(minifiedStackFrames[0], result.MinifiedStackFrames[0]);
-			Assert.AreEqual(stackFrameDeminification, result.DeminifiedStackFrameResults[0]);
+			Assert.Equal(1, result.DeminifiedStackFrameResults.Count);
+			Assert.Equal(minifiedStackFrames[0], result.MinifiedStackFrames[0]);
+			Assert.Equal(stackFrameDeminification, result.DeminifiedStackFrameResults[0]);
 		}
 	}
 }

--- a/tests/SourcemapToolkit.CallstackDeminifier.UnitTests/StackTraceParserUnitTests.cs
+++ b/tests/SourcemapToolkit.CallstackDeminifier.UnitTests/StackTraceParserUnitTests.cs
@@ -1,14 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
 namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 {
-	[TestClass]
+
 	public class StackTraceParserUnitTests
 	{
-		[TestMethod]
-		[ExpectedException(typeof (ArgumentNullException))]
+		[Fact]
 		public void ParseStackTrace_NullInput_ThrowsArgumentNullException()
 		{
 			// Arrange
@@ -16,10 +15,10 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 			string browserStackTrace = null;
 
 			// Act
-			stackTraceParser.ParseStackTrace(browserStackTrace);
+			Assert.Throws<ArgumentNullException>( ()=> stackTraceParser.ParseStackTrace(browserStackTrace));
 		}
 
-		[TestMethod]
+		[Fact]
 		public void ParseStackTrace_ChromeCallstack_GenerateCorrectNumberOfStackFrames()
 		{
 			// Arrange
@@ -34,10 +33,10 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 			List<StackFrame> stackTrace = stackTraceParser.ParseStackTrace(browserStackTrace);
 
 			// Assert
-			Assert.AreEqual(stackTrace.Count, 4);
+			Assert.Equal(stackTrace.Count, 4);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void ParseStackTrace_FireFoxCallstack_GenerateCorrectNumberOfStackFrames()
 		{
 			// Arrange
@@ -51,10 +50,10 @@ window.onload/<@http://localhost:19220/crashcauser.min.js:1:332";
 			List<StackFrame> stackTrace = stackTraceParser.ParseStackTrace(browserStackTrace);
 
 			// Assert
-			Assert.AreEqual(stackTrace.Count, 4);
+			Assert.Equal(stackTrace.Count, 4);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void ParseStackTrace_InternetExplorer11Callstack_GenerateCorrectNumberOfStackFrames()
 		{
 			// Arrange
@@ -68,11 +67,10 @@ window.onload/<@http://localhost:19220/crashcauser.min.js:1:332";
 			List<StackFrame> stackTrace = stackTraceParser.ParseStackTrace(browserStackTrace);
 
 			// Assert
-			Assert.AreEqual(stackTrace.Count, 3);
+			Assert.Equal(stackTrace.Count, 3);
 		}
 
-		[TestMethod]
-		[ExpectedException(typeof(ArgumentNullException))]
+		[Fact]
 		public void TryParseSingleStackFrame_NullInput_ThrowsNullArgumentException()
 		{
 			// Arrange
@@ -80,10 +78,10 @@ window.onload/<@http://localhost:19220/crashcauser.min.js:1:332";
 			string frame = null;
 
 			// Act
-			stackTraceParser.TryParseSingleStackFrame(frame);
+			Assert.Throws<ArgumentNullException>( ()=> stackTraceParser.TryParseSingleStackFrame(frame));
 		}
 
-		[TestMethod]
+		[Fact]
 		public void TryParseSingleStackFrame_EmptyString_ReturnNull()
 		{
 			// Arrange
@@ -94,10 +92,10 @@ window.onload/<@http://localhost:19220/crashcauser.min.js:1:332";
 			StackFrame result = stackTraceParser.TryParseSingleStackFrame(frame);
 
 			// Assert
-			Assert.IsNull(result);
+			Assert.Null(result);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void TryParseSingleStackFrame_NoMethodNameInInput_ReturnsStackFrameWithNullMethod()
 		{
 			// Arrange
@@ -108,13 +106,13 @@ window.onload/<@http://localhost:19220/crashcauser.min.js:1:332";
 			StackFrame result = stackTraceParser.TryParseSingleStackFrame(frame);
 
 			// Assert
-			Assert.AreEqual("http://localhost:19220/crashcauser.min.js", result.FilePath);
-			Assert.IsNull(result.MethodName);
-			Assert.AreEqual(0, result.SourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(33, result.SourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal("http://localhost:19220/crashcauser.min.js", result.FilePath);
+			Assert.Null(result.MethodName);
+			Assert.Equal(0, result.SourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(33, result.SourcePosition.ZeroBasedColumnNumber);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void TryParseSingleStackFrame_ChromeStackFrame_CorrectStackFrame()
 		{
 			// Arrange
@@ -125,13 +123,13 @@ window.onload/<@http://localhost:19220/crashcauser.min.js:1:332";
 			StackFrame result = stackTraceParser.TryParseSingleStackFrame(frame);
 
 			// Assert
-			Assert.AreEqual("http://localhost:19220/crashcauser.min.js", result.FilePath);
-			Assert.AreEqual("c", result.MethodName);
-			Assert.AreEqual(7, result.SourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(2, result.SourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal("http://localhost:19220/crashcauser.min.js", result.FilePath);
+			Assert.Equal("c", result.MethodName);
+			Assert.Equal(7, result.SourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(2, result.SourcePosition.ZeroBasedColumnNumber);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void TryParseSingleStackFrame_ChromeStackFrameWithNoMethodName_CorrectStackFrame()
 		{
 			// Arrange
@@ -142,13 +140,13 @@ window.onload/<@http://localhost:19220/crashcauser.min.js:1:332";
 			StackFrame result = stackTraceParser.TryParseSingleStackFrame(frame);
 
 			// Assert
-			Assert.AreEqual("http://localhost:19220/crashcauser.min.js", result.FilePath);
-			Assert.IsNull(result.MethodName);
-			Assert.AreEqual(9, result.SourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(12, result.SourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal("http://localhost:19220/crashcauser.min.js", result.FilePath);
+			Assert.Null(result.MethodName);
+			Assert.Equal(9, result.SourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(12, result.SourcePosition.ZeroBasedColumnNumber);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void TryParseSingleStackFrame_ChromeStackFrameWithScriptSubfolder_CorrectStackFrame()
 		{
 			// Arrange
@@ -159,13 +157,13 @@ window.onload/<@http://localhost:19220/crashcauser.min.js:1:332";
 			StackFrame result = stackTraceParser.TryParseSingleStackFrame(frame);
 
 			// Assert
-			Assert.AreEqual("http://localhost:19220/o/app_scripts/crashcauser.min.js", result.FilePath);
-			Assert.AreEqual("c", result.MethodName);
-			Assert.AreEqual(8, result.SourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(4, result.SourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal("http://localhost:19220/o/app_scripts/crashcauser.min.js", result.FilePath);
+			Assert.Equal("c", result.MethodName);
+			Assert.Equal(8, result.SourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(4, result.SourcePosition.ZeroBasedColumnNumber);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void TryParseSingleStackFrame_FireFoxStackFrame_CorrectStackFrame()
 		{
 			// Arrange
@@ -176,13 +174,13 @@ window.onload/<@http://localhost:19220/crashcauser.min.js:1:332";
 			StackFrame result = stackTraceParser.TryParseSingleStackFrame(frame);
 
 			// Assert
-			Assert.AreEqual("http://localhost:19220/crashcauser.min.js", result.FilePath);
-			Assert.AreEqual("c", result.MethodName);
-			Assert.AreEqual(3, result.SourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(51, result.SourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal("http://localhost:19220/crashcauser.min.js", result.FilePath);
+			Assert.Equal("c", result.MethodName);
+			Assert.Equal(3, result.SourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(51, result.SourcePosition.ZeroBasedColumnNumber);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void TryParseSingleStackFrame_IE11StackFrame_CorrectStackFrame()
 		{
 			// Arrange
@@ -193,13 +191,13 @@ window.onload/<@http://localhost:19220/crashcauser.min.js:1:332";
 			StackFrame result = stackTraceParser.TryParseSingleStackFrame(frame);
 
 			// Assert
-			Assert.AreEqual("http://localhost:19220/crashcauser.min.js", result.FilePath);
-			Assert.AreEqual("c", result.MethodName);
-			Assert.AreEqual(2, result.SourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(16, result.SourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal("http://localhost:19220/crashcauser.min.js", result.FilePath);
+			Assert.Equal("c", result.MethodName);
+			Assert.Equal(2, result.SourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(16, result.SourcePosition.ZeroBasedColumnNumber);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void TryParseSingleStackFrame_IE11StackFrameWithAnonymousFunction_CorrectStackFrame()
 		{
 			// Arrange
@@ -210,10 +208,10 @@ window.onload/<@http://localhost:19220/crashcauser.min.js:1:332";
 			StackFrame result = stackTraceParser.TryParseSingleStackFrame(frame);
 
 			// Assert
-			Assert.AreEqual("http://localhost:19220/crashcauser.min.js", result.FilePath);
-			Assert.AreEqual("Anonymous function", result.MethodName);
-			Assert.AreEqual(4, result.SourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(24, result.SourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal("http://localhost:19220/crashcauser.min.js", result.FilePath);
+			Assert.Equal("Anonymous function", result.MethodName);
+			Assert.Equal(4, result.SourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(24, result.SourcePosition.ZeroBasedColumnNumber);
 		}
 	}
 }

--- a/tests/SourcemapToolkit.SourcemapParser.UnitTests/Base64ConverterUnitTests.cs
+++ b/tests/SourcemapToolkit.SourcemapParser.UnitTests/Base64ConverterUnitTests.cs
@@ -1,63 +1,60 @@
 ﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
 namespace SourcemapToolkit.SourcemapParser.UnitTests
 {
-	[TestClass]
+
 	public class Base64ConverterUnitTests
 	{
-		[TestMethod]
+		[Fact]
 		public void FromBase64_ValidBase64InputC_CorrectIntegerOutput2()
 		{
 			// Act
 			int value = Base64Converter.FromBase64('C');
 
 			// Assert
-			Assert.AreEqual(2, value);
+			Assert.Equal(2, value);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void FromBase64_ValidBase64Input9_CorrectIntegerOutput61()
 		{
 			// Act
 			int value = Base64Converter.FromBase64('9');
 
 			// Assert
-			Assert.AreEqual(61, value);
+			Assert.Equal(61, value);
 		}
 
-		[TestMethod]
-		[ExpectedException(typeof(ArgumentOutOfRangeException))]
+		[Fact]
 		public void FromBase64_InvalidBase64Input_ThrowsException()
 		{
 			// Act
-			Base64Converter.FromBase64('@');
+			Assert.Throws<ArgumentOutOfRangeException>( ()=> Base64Converter.FromBase64('@'));
 		}
 
-		[TestMethod]
+		[Fact]
 		public void ToBase64_ValidIntegerInput61_CorrectBase64Output9()
 		{
 			// Act
 			char value = Base64Converter.ToBase64(61);
 
 			// Assert
-			Assert.AreEqual('9', value);
+			Assert.Equal('9', value);
 		}
 
-		[TestMethod]
-		[ExpectedException(typeof(ArgumentOutOfRangeException))]
+		[Fact]
 		public void ToBase64_NegativeIntegerInput_ThrowsException()
 		{
 			// Act
-			Base64Converter.ToBase64(-1);
+			Assert.Throws<ArgumentOutOfRangeException>( ()=> Base64Converter.ToBase64(-1));
 		}
 
-		[TestMethod]
-		[ExpectedException(typeof(ArgumentOutOfRangeException))]
+		[Fact]
 		public void ToBase64_InvalidIntegerInput_ThrowsException()
 		{
 			// Act
-			Base64Converter.ToBase64(64);
+			Assert.Throws<ArgumentOutOfRangeException>( ()=> Base64Converter.ToBase64(64));
 		}
 	}
 }

--- a/tests/SourcemapToolkit.SourcemapParser.UnitTests/Base64VlqDecoderUnitTests.cs
+++ b/tests/SourcemapToolkit.SourcemapParser.UnitTests/Base64VlqDecoderUnitTests.cs
@@ -1,12 +1,12 @@
 ﻿using System.Collections.Generic;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
 namespace SourcemapToolkit.SourcemapParser.UnitTests
 {
-	[TestClass]
+
 	public class Base64VlqDecoderUnitTests
 	{
-		[TestMethod]
+		[Fact]
 		public void Base64VlqDecoder_SingleEncodedValue_ListWithOnlyOneValue()
 		{
 			// Arrange
@@ -16,10 +16,10 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 			List<int> result = Base64VlqDecoder.Decode(input);
 
 			// Assert
-			CollectionAssert.AreEqual(new List<int> { 701 }, result);
+			Assert.Equal(new List<int> { 701 }, result);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void Base64VlqDecoder_MultipleEncodedValues_ListWithMultipleValues()
 		{
 			// Arrange
@@ -29,10 +29,10 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 			List<int> result = Base64VlqDecoder.Decode(input);
 
 			// Assert
-			CollectionAssert.AreEqual(new List<int> { 0, 0, 16, 1 }, result);
+			Assert.Equal(new List<int> { 0, 0, 16, 1 }, result);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void Base64VlqDecoder_InputIncludesNegativeValue_ListContainsNegativeValue()
 		{
 			// Arrange
@@ -42,7 +42,7 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 			List<int> result = Base64VlqDecoder.Decode(input);
 
 			// Assert
-			CollectionAssert.AreEqual(new List<int> { 1, 0, 1, -15 }, result);
+			Assert.Equal(new List<int> { 1, 0, 1, -15 }, result);
 		}
 	}
 }

--- a/tests/SourcemapToolkit.SourcemapParser.UnitTests/Base64VlqEncoderUnitTests.cs
+++ b/tests/SourcemapToolkit.SourcemapParser.UnitTests/Base64VlqEncoderUnitTests.cs
@@ -1,13 +1,13 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Xunit;
 using System.Collections.Generic;
 using System.Text;
 
 namespace SourcemapToolkit.SourcemapParser.UnitTests
 {
-	[TestClass]
+
 	public class Base64VlqEncoderUnitTests
 	{
-		[TestMethod]
+		[Fact]
 		public void Base64VlqEncoder_SmallValue_ListWithOnlyOneValue()
 		{
 			// Act
@@ -15,10 +15,10 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 			Base64VlqEncoder.Encode(result, 15);
 
 			// Assert
-			Assert.AreEqual("e", result.ToString());
+			Assert.Equal("e", result.ToString());
 		}
 
-		[TestMethod]
+		[Fact]
 		public void Base64VlqEncoder_LargeValue_ListWithOnlyMultipleValues()
 		{
 			// Act
@@ -26,10 +26,10 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 			Base64VlqEncoder.Encode(result, 701);
 
 			// Assert
-			Assert.AreEqual("6rB", result.ToString());
+			Assert.Equal("6rB", result.ToString());
 		}
 
-		[TestMethod]
+		[Fact]
 		public void Base64VlqEncoder_NegativeValue_ListWithCorrectValue()
 		{
 			// Act
@@ -37,7 +37,7 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 			Base64VlqEncoder.Encode(result, -15);
 
 			// Assert
-			Assert.AreEqual("f", result.ToString());
+			Assert.Equal("f", result.ToString());
 		}
 
 	}

--- a/tests/SourcemapToolkit.SourcemapParser.UnitTests/MappingsListParserUnitTests.cs
+++ b/tests/SourcemapToolkit.SourcemapParser.UnitTests/MappingsListParserUnitTests.cs
@@ -1,15 +1,14 @@
 ﻿
 using System;
 using System.Collections.Generic;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
 namespace SourcemapToolkit.SourcemapParser.UnitTests
 {
-	[TestClass]
+
 	public class MappingsListParserUnitTests
 	{
-		[TestMethod]
-		[ExpectedException(typeof(ArgumentNullException))]
+		[Fact]
 		public void ParseSingleMappingSegment_NullSegmentFields_ThrowArgumentNullException()
 		{
 			// Arrange
@@ -18,11 +17,10 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 			List<int> segmentFields = null;
 
 			// Act
-			mappingsListParser.ParseSingleMappingSegment(segmentFields, mappingsParserState);
+			Assert.Throws<ArgumentNullException>( () => mappingsListParser.ParseSingleMappingSegment(segmentFields, mappingsParserState));
 		}
 
-		[TestMethod]
-		[ExpectedException(typeof(ArgumentOutOfRangeException))]
+		[Fact]
 		public void ParseSingleMappingSegment_0SegmentFields_ArgumentOutOfRangeException()
 		{
 			// Arrange
@@ -31,11 +29,10 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 			List<int> segmentFields = new List<int>();
 
 			// Act
-			mappingsListParser.ParseSingleMappingSegment(segmentFields, mappingsParserState);
+			Assert.Throws<ArgumentOutOfRangeException>( () => mappingsListParser.ParseSingleMappingSegment(segmentFields, mappingsParserState));
 		}
 
-		[TestMethod]
-		[ExpectedException(typeof(ArgumentOutOfRangeException))]
+		[Fact]
 		public void ParseSingleMappingSegment_2SegmentFields_ArgumentOutOfRangeException()
 		{
 			// Arrange
@@ -44,11 +41,10 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 			List<int> segmentFields = new List<int> { 1, 2 };
 
 			// Act
-			mappingsListParser.ParseSingleMappingSegment(segmentFields, mappingsParserState);
+			Assert.Throws<ArgumentOutOfRangeException>( () => mappingsListParser.ParseSingleMappingSegment(segmentFields, mappingsParserState));
 		}
 
-		[TestMethod]
-		[ExpectedException(typeof(ArgumentOutOfRangeException))]
+		[Fact]
 		public void ParseSingleMappingSegment_3SegmentFields_ArgumentOutOfRangeException()
 		{
 			// Arrange
@@ -57,10 +53,10 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 			List<int> segmentFields = new List<int> { 1, 2, 3 };
 
 			// Act
-			mappingsListParser.ParseSingleMappingSegment(segmentFields, mappingsParserState);
+			Assert.Throws<ArgumentOutOfRangeException>( () => mappingsListParser.ParseSingleMappingSegment(segmentFields, mappingsParserState));
 		}
 
-		[TestMethod]
+		[Fact]
 		public void ParseSingleMappingSegment_NoPreviousStateSingleSegment_GeneratedColumnSet()
 		{
 			// Arrange
@@ -72,15 +68,15 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 			NumericMappingEntry result = mappingsListParser.ParseSingleMappingSegment(segmentFields, mappingsParserState);
 
 			// Assert
-			Assert.AreEqual(0, result.GeneratedLineNumber);
-			Assert.AreEqual(16, result.GeneratedColumnNumber);
-			Assert.IsFalse(result.OriginalSourceFileIndex.HasValue);
-			Assert.IsFalse(result.OriginalLineNumber.HasValue);
-			Assert.IsFalse(result.OriginalColumnNumber.HasValue);
-			Assert.IsFalse(result.OriginalNameIndex.HasValue);
+			Assert.Equal(0, result.GeneratedLineNumber);
+			Assert.Equal(16, result.GeneratedColumnNumber);
+			Assert.False(result.OriginalSourceFileIndex.HasValue);
+			Assert.False(result.OriginalLineNumber.HasValue);
+			Assert.False(result.OriginalColumnNumber.HasValue);
+			Assert.False(result.OriginalNameIndex.HasValue);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void ParseSingleMappingSegment_NoPreviousState4Segments_OriginalNameIndexNotSetInMappingEntry()
 		{
 			// Arrange
@@ -92,15 +88,15 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 			NumericMappingEntry result = mappingsListParser.ParseSingleMappingSegment(segmentFields, mappingsParserState);
 
 			// Assert
-			Assert.AreEqual(0, result.GeneratedLineNumber);
-			Assert.AreEqual(1, result.GeneratedColumnNumber);
-			Assert.AreEqual(1, result.OriginalSourceFileIndex);
-			Assert.AreEqual(2, result.OriginalLineNumber);
-			Assert.AreEqual(4, result.OriginalColumnNumber);
-			Assert.IsFalse(result.OriginalNameIndex.HasValue);
+			Assert.Equal(0, result.GeneratedLineNumber);
+			Assert.Equal(1, result.GeneratedColumnNumber);
+			Assert.Equal(1, result.OriginalSourceFileIndex);
+			Assert.Equal(2, result.OriginalLineNumber);
+			Assert.Equal(4, result.OriginalColumnNumber);
+			Assert.False(result.OriginalNameIndex.HasValue);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void ParseSingleMappingSegment_NoPreviousState5Segments_AllFieldsSetInMappingEntry()
 		{
 			// Arrange
@@ -112,15 +108,15 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 			NumericMappingEntry result = mappingsListParser.ParseSingleMappingSegment(segmentFields, mappingsParserState);
 
 			// Assert
-			Assert.AreEqual(0, result.GeneratedLineNumber);
-			Assert.AreEqual(1, result.GeneratedColumnNumber);
-			Assert.AreEqual(3, result.OriginalSourceFileIndex);
-			Assert.AreEqual(6, result.OriginalLineNumber);
-			Assert.AreEqual(10, result.OriginalColumnNumber);
-			Assert.AreEqual(15, result.OriginalNameIndex);
+			Assert.Equal(0, result.GeneratedLineNumber);
+			Assert.Equal(1, result.GeneratedColumnNumber);
+			Assert.Equal(3, result.OriginalSourceFileIndex);
+			Assert.Equal(6, result.OriginalLineNumber);
+			Assert.Equal(10, result.OriginalColumnNumber);
+			Assert.Equal(15, result.OriginalNameIndex);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void ParseSingleMappingSegment_HasPreviousState5Segments_AllFieldsSetIncrementally()
 		{
 			// Arrange
@@ -136,15 +132,15 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 			NumericMappingEntry result = mappingsListParser.ParseSingleMappingSegment(segmentFields, mappingsParserState);
 
 			// Assert
-			Assert.AreEqual(0, result.GeneratedLineNumber);
-			Assert.AreEqual(7, result.GeneratedColumnNumber);
-			Assert.AreEqual(9, result.OriginalSourceFileIndex);
-			Assert.AreEqual(11, result.OriginalLineNumber);
-			Assert.AreEqual(13, result.OriginalColumnNumber);
-			Assert.AreEqual(15, result.OriginalNameIndex);
+			Assert.Equal(0, result.GeneratedLineNumber);
+			Assert.Equal(7, result.GeneratedColumnNumber);
+			Assert.Equal(9, result.OriginalSourceFileIndex);
+			Assert.Equal(11, result.OriginalLineNumber);
+			Assert.Equal(13, result.OriginalColumnNumber);
+			Assert.Equal(15, result.OriginalNameIndex);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void ParseMappings_SingleSemicolon_GeneratedLineNumberNotIncremented()
 		{
 			// Arrange
@@ -157,12 +153,12 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 			List<MappingEntry> mappingsList = mappingsListParser.ParseMappings(mappingsString, names, sources);
 
 			// Assert
-			Assert.AreEqual(2, mappingsList.Count);
-			Assert.AreEqual(0, mappingsList[0].GeneratedSourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(0, mappingsList[1].GeneratedSourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(2, mappingsList.Count);
+			Assert.Equal(0, mappingsList[0].GeneratedSourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(0, mappingsList[1].GeneratedSourcePosition.ZeroBasedLineNumber);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void ParseMappings_TwoSemicolons_GeneratedLineNumberIncremented()
 		{
 			// Arrange
@@ -175,12 +171,12 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 			List<MappingEntry> mappingsList = mappingsListParser.ParseMappings(mappingsString, names, sources);
 
 			// Assert
-			Assert.AreEqual(2, mappingsList.Count);
-			Assert.AreEqual(0, mappingsList[0].GeneratedSourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(1, mappingsList[1].GeneratedSourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(2, mappingsList.Count);
+			Assert.Equal(0, mappingsList[0].GeneratedSourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(1, mappingsList[1].GeneratedSourcePosition.ZeroBasedLineNumber);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void ParseMappings_BackToBackSemiColons_GeneratedLineNumberIncremented()
 		{
 			// Arrange
@@ -193,9 +189,9 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 			List<MappingEntry> mappingsList = mappingsListParser.ParseMappings(mappingsString, names, sources);
 
 			// Assert
-			Assert.AreEqual(2, mappingsList.Count);
-			Assert.AreEqual(0, mappingsList[0].GeneratedSourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(2, mappingsList[1].GeneratedSourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(2, mappingsList.Count);
+			Assert.Equal(0, mappingsList[0].GeneratedSourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(2, mappingsList[1].GeneratedSourcePosition.ZeroBasedLineNumber);
 		}
 	}
 }

--- a/tests/SourcemapToolkit.SourcemapParser.UnitTests/NumericMappingEntryUnitTests.cs
+++ b/tests/SourcemapToolkit.SourcemapParser.UnitTests/NumericMappingEntryUnitTests.cs
@@ -1,12 +1,12 @@
 ﻿using System.Collections.Generic;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
 namespace SourcemapToolkit.SourcemapParser.UnitTests
 {
-	[TestClass]
+
 	public class NumericMappingEntryUnitTests
 	{
-		[TestMethod]
+		[Fact]
 		public void ToMappingEntry_ContainsGeneratedSourcePosition_CorrectMappingEntryFieldsPopulated()
 		{
 			// Arrange
@@ -22,14 +22,14 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 			MappingEntry mappingEntry = numericMappingEntry.ToMappingEntry(names, sources);
 
 			// Assert
-			Assert.AreEqual(12, mappingEntry.GeneratedSourcePosition.ZeroBasedColumnNumber);
-			Assert.AreEqual(13, mappingEntry.GeneratedSourcePosition.ZeroBasedLineNumber);
-			Assert.IsNull(mappingEntry.OriginalSourcePosition);
-			Assert.IsNull(mappingEntry.OriginalFileName);
-			Assert.IsNull(mappingEntry.OriginalName);
+			Assert.Equal(12, mappingEntry.GeneratedSourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal(13, mappingEntry.GeneratedSourcePosition.ZeroBasedLineNumber);
+			Assert.Null(mappingEntry.OriginalSourcePosition);
+			Assert.Null(mappingEntry.OriginalFileName);
+			Assert.Null(mappingEntry.OriginalName);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void ToMappingEntry_ContainsGeneratedAndOriginalSourcePosition_CorrectMappingEntryFieldsPopulated()
 		{
 			// Arrange
@@ -47,15 +47,15 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 			MappingEntry mappingEntry = numericMappingEntry.ToMappingEntry(names, sources);
 
 			// Assert
-			Assert.AreEqual(2, mappingEntry.GeneratedSourcePosition.ZeroBasedColumnNumber);
-			Assert.AreEqual(3, mappingEntry.GeneratedSourcePosition.ZeroBasedLineNumber);
-			Assert.AreEqual(16, mappingEntry.OriginalSourcePosition.ZeroBasedColumnNumber);
-			Assert.AreEqual(23, mappingEntry.OriginalSourcePosition.ZeroBasedLineNumber);
-			Assert.IsNull(mappingEntry.OriginalFileName);
-			Assert.IsNull(mappingEntry.OriginalName);
+			Assert.Equal(2, mappingEntry.GeneratedSourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal(3, mappingEntry.GeneratedSourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(16, mappingEntry.OriginalSourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal(23, mappingEntry.OriginalSourcePosition.ZeroBasedLineNumber);
+			Assert.Null(mappingEntry.OriginalFileName);
+			Assert.Null(mappingEntry.OriginalName);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void ToMappingEntry_ContainsGeneratedPositionNameIndexAndSourcesIndex_CorrectMappingEntryFieldsPopulated()
 		{
 			// Arrange
@@ -73,11 +73,11 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 			MappingEntry mappingEntry = numericMappingEntry.ToMappingEntry(names, sources);
 
 			// Assert
-			Assert.AreEqual(8, mappingEntry.GeneratedSourcePosition.ZeroBasedColumnNumber);
-			Assert.AreEqual(48, mappingEntry.GeneratedSourcePosition.ZeroBasedLineNumber);
-			Assert.IsNull(mappingEntry.OriginalSourcePosition);
-			Assert.AreEqual("three", mappingEntry.OriginalFileName);
-			Assert.AreEqual("bar", mappingEntry.OriginalName);
+			Assert.Equal(8, mappingEntry.GeneratedSourcePosition.ZeroBasedColumnNumber);
+			Assert.Equal(48, mappingEntry.GeneratedSourcePosition.ZeroBasedLineNumber);
+			Assert.Null(mappingEntry.OriginalSourcePosition);
+			Assert.Equal("three", mappingEntry.OriginalFileName);
+			Assert.Equal("bar", mappingEntry.OriginalName);
 		}
 	}
 }

--- a/tests/SourcemapToolkit.SourcemapParser.UnitTests/SourceMapGeneratorUnitTests.cs
+++ b/tests/SourcemapToolkit.SourcemapParser.UnitTests/SourceMapGeneratorUnitTests.cs
@@ -1,14 +1,14 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Xunit;
 using System;
 using System.Collections.Generic;
 using System.Text;
 
 namespace SourcemapToolkit.SourcemapParser.UnitTests
 {
-	[TestClass]
+
 	public class SourceMapGeneratorUnitTests
 	{
-		[TestMethod]
+		[Fact]
 		public void SerializeMappingEntry_DifferentLineNumber_SemicolonAdded()
 		{
 			// Arrange
@@ -30,10 +30,10 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 			sourceMapGenerator.SerializeMappingEntry(entry, state, result);
 
 			// Assert
-			Assert.IsTrue(result.ToString().IndexOf(';') >= 0);
+			Assert.True(result.ToString().IndexOf(';') >= 0);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void SerializeMappingEntry_NoOriginalFileName_OneSegment()
 		{
 			// Arrange
@@ -52,10 +52,10 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 			sourceMapGenerator.SerializeMappingEntry(entry, state, result);
 
 			// Assert
-			Assert.AreEqual("U", result.ToString());
+			Assert.Equal("U", result.ToString());
 		}
 
-		[TestMethod]
+		[Fact]
 		public void SerializeMappingEntry_WithOriginalFileNameNoOriginalName_FourSegments()
 		{
 			// Arrange
@@ -76,10 +76,10 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 			sourceMapGenerator.SerializeMappingEntry(entry, state, result);
 
 			// Assert
-			Assert.AreEqual(",UAAK", result.ToString());
+			Assert.Equal(",UAAK", result.ToString());
 		}
 
-		[TestMethod]
+		[Fact]
 		public void SerializeMappingEntry_WithOriginalFileNameAndOriginalName_FiveSegments()
 		{
 			// Arrange
@@ -101,11 +101,10 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 			sourceMapGenerator.SerializeMappingEntry(entry, state, result);
 
 			// Assert
-			Assert.AreEqual("KACMA", result.ToString());
+			Assert.Equal("KACMA", result.ToString());
 		}
 
-		[TestMethod]
-		[ExpectedException(typeof(ArgumentNullException))]
+		[Fact]
 		public void SerializeMapping_NullInput_ThrowsException()
 		{
 			// Arrange
@@ -113,10 +112,10 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 			SourceMap input = null;
 
 			// Act
-			string output = sourceMapGenerator.SerializeMapping(input);
+			Assert.Throws<ArgumentNullException>(() => sourceMapGenerator.SerializeMapping(input));
 		}
 
-		[TestMethod]
+		[Fact]
 		public void SerializeMapping_SimpleSourceMap_CorrectlySerialized()
 		{
 			// Arrange
@@ -127,11 +126,10 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
             string output = sourceMapGenerator.SerializeMapping(input);
 
 			// Assert
-			Assert.AreEqual("{\"version\":3,\"file\":\"CommonIntl\",\"mappings\":\"AACAA,aAAA,CAAc;\",\"sources\":[\"input/CommonIntl.js\"],\"names\":[\"CommonStrings\",\"afrikaans\"]}", output);
+			Assert.Equal("{\"version\":3,\"file\":\"CommonIntl\",\"mappings\":\"AACAA,aAAA,CAAc;\",\"sources\":[\"input/CommonIntl.js\"],\"names\":[\"CommonStrings\",\"afrikaans\"]}", output);
 		}
 
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentNullException))]
+        [Fact]
         public void SerializeMappingIntoBast64_NullInput_ThrowsException()
         {
             // Arrange
@@ -139,10 +137,10 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
             SourceMap input = null;
 
             // Act
-            string output = sourceMapGenerator.GenerateSourceMapInlineComment(input);
+            Assert.Throws<ArgumentNullException>(() => sourceMapGenerator.GenerateSourceMapInlineComment(input));
         }
 
-        [TestMethod]
+        [Fact]
         public void SerializeMappingBase64_SimpleSourceMap_CorrectlySerialized()
         {
             // Arrange
@@ -153,7 +151,7 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
             string output = sourceMapGenerator.GenerateSourceMapInlineComment(input);
 
             // Assert
-            Assert.AreEqual("//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiQ29tbW9uSW50bCIsIm1hcHBpbmdzIjoiQUFDQUEsYUFBQSxDQUFjOyIsInNvdXJjZXMiOlsiaW5wdXQvQ29tbW9uSW50bC5qcyJdLCJuYW1lcyI6WyJDb21tb25TdHJpbmdzIiwiYWZyaWthYW5zIl19", output);
+            Assert.Equal("//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiQ29tbW9uSW50bCIsIm1hcHBpbmdzIjoiQUFDQUEsYUFBQSxDQUFjOyIsInNvdXJjZXMiOlsiaW5wdXQvQ29tbW9uSW50bC5qcyJdLCJuYW1lcyI6WyJDb21tb25TdHJpbmdzIiwiYWZyaWthYW5zIl19", output);
         }
 
         private SourceMap GetSimpleSourceMap()

--- a/tests/SourcemapToolkit.SourcemapParser.UnitTests/SourceMapParserUnitTests.cs
+++ b/tests/SourcemapToolkit.SourcemapParser.UnitTests/SourceMapParserUnitTests.cs
@@ -1,12 +1,12 @@
 ﻿using System.IO;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
 namespace SourcemapToolkit.SourcemapParser.UnitTests
 {
-	[TestClass]
+
 	public class SourceMapParserUnitTests
 	{
-		[TestMethod]
+		[Fact]
 		public void ParseSourceMap_NullInputStream_ReturnsNull()
 		{
 			// Arrange
@@ -17,10 +17,10 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 			SourceMap output = sourceMapParser.ParseSourceMap(input);
 
 			// Assert
-			Assert.IsNull(output);
+			Assert.Null(output);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void ParseSourceMap_SimpleSourceMap_CorrectlyParsed()
 		{
 			// Arrange
@@ -31,14 +31,14 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 			SourceMap output = sourceMapParser.ParseSourceMap(UnitTestUtils.StreamReaderFromString(input));
 
 			// Assert
-			Assert.AreEqual(3, output.Version);
-			Assert.AreEqual("CommonIntl", output.File);
-			Assert.AreEqual("AACAA,aAAA,CAAc", output.Mappings);
-			Assert.AreEqual(1, output.Sources.Count);
-			Assert.AreEqual("input/CommonIntl.js", output.Sources[0]);
-			Assert.AreEqual(2, output.Names.Count);
-			Assert.AreEqual("CommonStrings", output.Names[0]);
-			Assert.AreEqual("afrikaans", output.Names[1]);
+			Assert.Equal(3, output.Version);
+			Assert.Equal("CommonIntl", output.File);
+			Assert.Equal("AACAA,aAAA,CAAc", output.Mappings);
+			Assert.Equal(1, output.Sources.Count);
+			Assert.Equal("input/CommonIntl.js", output.Sources[0]);
+			Assert.Equal(2, output.Names.Count);
+			Assert.Equal("CommonStrings", output.Names[0]);
+			Assert.Equal("afrikaans", output.Names[1]);
 		}
 	}
 }

--- a/tests/SourcemapToolkit.SourcemapParser.UnitTests/SourceMapTransformerUnitTests.cs
+++ b/tests/SourcemapToolkit.SourcemapParser.UnitTests/SourceMapTransformerUnitTests.cs
@@ -1,17 +1,16 @@
 ﻿using System.Collections.Generic;
 
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
 namespace SourcemapToolkit.SourcemapParser.UnitTests
 {
     /// <summary>
     /// Summary description for SourceMapTransformerUnitTests
     /// </summary>
-    [TestClass]
     public class SourceMapTransformerUnitTests
     {
 
-        [TestMethod]
+        [Fact]
         public void FlattenMap_ReturnsOnlyLineInformation()
         {
             // Arrange
@@ -31,17 +30,17 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
             SourceMap linesOnlyMap = SourceMapTransformer.Flatten(map);
 
             // Assert
-            Assert.IsNotNull(linesOnlyMap);
-            Assert.AreEqual(1, linesOnlyMap.Sources.Count);
-            Assert.AreEqual(1, linesOnlyMap.SourcesContent.Count);
-            Assert.AreEqual(1, linesOnlyMap.ParsedMappings.Count);
-            Assert.AreEqual(1, linesOnlyMap.ParsedMappings[0].GeneratedSourcePosition.ZeroBasedLineNumber);
-            Assert.AreEqual(0, linesOnlyMap.ParsedMappings[0].GeneratedSourcePosition.ZeroBasedColumnNumber);
-            Assert.AreEqual(2, linesOnlyMap.ParsedMappings[0].OriginalSourcePosition.ZeroBasedLineNumber);
-            Assert.AreEqual(0, linesOnlyMap.ParsedMappings[0].OriginalSourcePosition.ZeroBasedColumnNumber);
+            Assert.NotNull(linesOnlyMap);
+            Assert.Equal(1, linesOnlyMap.Sources.Count);
+            Assert.Equal(1, linesOnlyMap.SourcesContent.Count);
+            Assert.Equal(1, linesOnlyMap.ParsedMappings.Count);
+            Assert.Equal(1, linesOnlyMap.ParsedMappings[0].GeneratedSourcePosition.ZeroBasedLineNumber);
+            Assert.Equal(0, linesOnlyMap.ParsedMappings[0].GeneratedSourcePosition.ZeroBasedColumnNumber);
+            Assert.Equal(2, linesOnlyMap.ParsedMappings[0].OriginalSourcePosition.ZeroBasedLineNumber);
+            Assert.Equal(0, linesOnlyMap.ParsedMappings[0].OriginalSourcePosition.ZeroBasedColumnNumber);
         }
 
-        [TestMethod]
+        [Fact]
         public void FlattenMap_MultipleMappingsSameLine_ReturnsOnlyOneMappingPerLine()
         {
             // Arrange
@@ -65,17 +64,17 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
             SourceMap linesOnlyMap = SourceMapTransformer.Flatten(map);
 
             // Assert
-            Assert.IsNotNull(linesOnlyMap);
-            Assert.AreEqual(1, linesOnlyMap.Sources.Count);
-            Assert.AreEqual(1, linesOnlyMap.SourcesContent.Count);
-            Assert.AreEqual(1, linesOnlyMap.ParsedMappings.Count);
-            Assert.AreEqual(1, linesOnlyMap.ParsedMappings[0].GeneratedSourcePosition.ZeroBasedLineNumber);
-            Assert.AreEqual(0, linesOnlyMap.ParsedMappings[0].GeneratedSourcePosition.ZeroBasedColumnNumber);
-            Assert.AreEqual(2, linesOnlyMap.ParsedMappings[0].OriginalSourcePosition.ZeroBasedLineNumber);
-            Assert.AreEqual(0, linesOnlyMap.ParsedMappings[0].OriginalSourcePosition.ZeroBasedColumnNumber);
+            Assert.NotNull(linesOnlyMap);
+            Assert.Equal(1, linesOnlyMap.Sources.Count);
+            Assert.Equal(1, linesOnlyMap.SourcesContent.Count);
+            Assert.Equal(1, linesOnlyMap.ParsedMappings.Count);
+            Assert.Equal(1, linesOnlyMap.ParsedMappings[0].GeneratedSourcePosition.ZeroBasedLineNumber);
+            Assert.Equal(0, linesOnlyMap.ParsedMappings[0].GeneratedSourcePosition.ZeroBasedColumnNumber);
+            Assert.Equal(2, linesOnlyMap.ParsedMappings[0].OriginalSourcePosition.ZeroBasedLineNumber);
+            Assert.Equal(0, linesOnlyMap.ParsedMappings[0].OriginalSourcePosition.ZeroBasedColumnNumber);
         }
 
-        [TestMethod]
+        [Fact]
         public void FlattenMap_MultipleOriginalLineToSameGeneratedLine_ReturnsFirstOriginalLine()
         {
             // Arrange
@@ -99,14 +98,14 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
             SourceMap linesOnlyMap = SourceMapTransformer.Flatten(map);
 
             // Assert
-            Assert.IsNotNull(linesOnlyMap);
-            Assert.AreEqual(1, linesOnlyMap.Sources.Count);
-            Assert.AreEqual(1, linesOnlyMap.SourcesContent.Count);
-            Assert.AreEqual(1, linesOnlyMap.ParsedMappings.Count);
-            Assert.AreEqual(1, linesOnlyMap.ParsedMappings[0].GeneratedSourcePosition.ZeroBasedLineNumber);
-            Assert.AreEqual(0, linesOnlyMap.ParsedMappings[0].GeneratedSourcePosition.ZeroBasedColumnNumber);
-            Assert.AreEqual(2, linesOnlyMap.ParsedMappings[0].OriginalSourcePosition.ZeroBasedLineNumber);
-            Assert.AreEqual(0, linesOnlyMap.ParsedMappings[0].OriginalSourcePosition.ZeroBasedColumnNumber);
+            Assert.NotNull(linesOnlyMap);
+            Assert.Equal(1, linesOnlyMap.Sources.Count);
+            Assert.Equal(1, linesOnlyMap.SourcesContent.Count);
+            Assert.Equal(1, linesOnlyMap.ParsedMappings.Count);
+            Assert.Equal(1, linesOnlyMap.ParsedMappings[0].GeneratedSourcePosition.ZeroBasedLineNumber);
+            Assert.Equal(0, linesOnlyMap.ParsedMappings[0].GeneratedSourcePosition.ZeroBasedColumnNumber);
+            Assert.Equal(2, linesOnlyMap.ParsedMappings[0].OriginalSourcePosition.ZeroBasedLineNumber);
+            Assert.Equal(0, linesOnlyMap.ParsedMappings[0].OriginalSourcePosition.ZeroBasedColumnNumber);
         }
     }
 }

--- a/tests/SourcemapToolkit.SourcemapParser.UnitTests/SourceMapUnitTests.cs
+++ b/tests/SourcemapToolkit.SourcemapParser.UnitTests/SourceMapUnitTests.cs
@@ -1,13 +1,13 @@
 ﻿using System.Collections.Generic;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 using System;
 
 namespace SourcemapToolkit.SourcemapParser.UnitTests
 {
-	[TestClass]
+
 	public class SourceMapUnitTests
 	{
-		[TestMethod]
+		[Fact]
 		public void GetMappingEntryForGeneratedSourcePosition_NullMappingList_ReturnNull()
 		{
 			// Arrange
@@ -18,10 +18,10 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 			MappingEntry result = sourceMap.GetMappingEntryForGeneratedSourcePosition(sourcePosition);
 
 			// Asset
-			Assert.IsNull(result);
+			Assert.Null(result);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void GetMappingEntryForGeneratedSourcePosition_NoMatchingEntryInMappingList_ReturnNull()
 		{
 			// Arrange
@@ -39,10 +39,10 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 			MappingEntry result = sourceMap.GetMappingEntryForGeneratedSourcePosition(sourcePosition);
 
 			// Asset
-			Assert.IsNull(result);
+			Assert.Null(result);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void GetMappingEntryForGeneratedSourcePosition_MatchingEntryInMappingList_ReturnMatchingEntry()
 		{
 			// Arrange
@@ -65,10 +65,10 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 			MappingEntry result = sourceMap.GetMappingEntryForGeneratedSourcePosition(sourcePosition);
 
 			// Asset
-			Assert.AreEqual(matchingMappingEntry, result);
+			Assert.Equal(matchingMappingEntry, result);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void GetMappingEntryForGeneratedSourcePosition_NoExactMatchHasSimilarOnSameLine_ReturnSimilarEntry()
 		{
 			// Arrange
@@ -91,10 +91,10 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 			MappingEntry result = sourceMap.GetMappingEntryForGeneratedSourcePosition(sourcePosition);
 
 			// Asset
-			Assert.AreEqual(matchingMappingEntry, result);
+			Assert.Equal(matchingMappingEntry, result);
 		}
 
-        [TestMethod]
+        [Fact]
         public void GetMappingEntryForGeneratedSourcePosition_NoExactMatchHasSimilarOnDifferentLinesLine_ReturnSimilarEntry()
         {
             // Arrange
@@ -117,10 +117,10 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
             MappingEntry result = sourceMap.GetMappingEntryForGeneratedSourcePosition(sourcePosition);
 
             // Asset
-            Assert.AreEqual(matchingMappingEntry, result);
+            Assert.Equal(matchingMappingEntry, result);
         }
 
-		[TestMethod]
+		[Fact]
 		public void GetRootMappingEntryForGeneratedSourcePosition_NoChildren_ReturnsSameEntry()
 		{
 			// Arrange
@@ -138,11 +138,10 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 			MappingEntry rootEntry = sourceMap.GetMappingEntryForGeneratedSourcePosition(generated1);
 
 			// Assert
-			Assert.AreEqual(rootEntry, mappingEntry);
+			Assert.Equal(rootEntry, mappingEntry);
 		}
 
-		[TestMethod]
-		[ExpectedException(typeof(ArgumentNullException))]
+		[Fact]
 		public void ApplyMap_NullSubmap_ThrowsException()
 		{
 			// Arrange
@@ -158,12 +157,12 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 			};
 
 			// Act
-			SourceMap combinedMap = map.ApplySourceMap(null);
+			Assert.Throws<ArgumentNullException>(() => map.ApplySourceMap(null));
 
 			// Assert (decorated expected exception)
 		}
 
-		[TestMethod]
+		[Fact]
 		public void ApplyMap_NoMatchingSources_ReturnsSameMap()
 		{
 			// Arrange
@@ -193,12 +192,12 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 			SourceMap combinedMap = parentMap.ApplySourceMap(childMap);
 
 			// Assert
-			Assert.IsNotNull(combinedMap);
+			Assert.NotNull(combinedMap);
 			MappingEntry firstMapping = combinedMap.ParsedMappings[0];
-			Assert.IsTrue(firstMapping.IsValueEqual(parentMapping));
+			Assert.True(firstMapping.IsValueEqual(parentMapping));
 		}
 
-        [TestMethod]
+        [Fact]
         public void ApplyMap_NoMatchingMappings_ReturnsSameMap()
         {
             // Arrange
@@ -228,12 +227,12 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
             SourceMap combinedMap = parentMap.ApplySourceMap(childMap);
 
             // Assert
-            Assert.IsNotNull(combinedMap);
+            Assert.NotNull(combinedMap);
             MappingEntry firstMapping = combinedMap.ParsedMappings[0];
-            Assert.IsTrue(firstMapping.IsValueEqual(parentMapping));
+            Assert.True(firstMapping.IsValueEqual(parentMapping));
         }
 
-        [TestMethod]
+        [Fact]
 		public void ApplyMap_MatchingSources_ReturnsCorrectMap()
 		{
             // Expect mapping with same source filename as the applied source-map to be replaced
@@ -265,14 +264,14 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 			SourceMap combinedMap = parentMap.ApplySourceMap(childMap);
 
 			// Assert
-			Assert.IsNotNull(combinedMap);
-			Assert.AreEqual(1, combinedMap.ParsedMappings.Count);
-			Assert.AreEqual(1, combinedMap.Sources.Count);
+			Assert.NotNull(combinedMap);
+			Assert.Equal(1, combinedMap.ParsedMappings.Count);
+			Assert.Equal(1, combinedMap.Sources.Count);
 			MappingEntry rootMapping = combinedMap.GetMappingEntryForGeneratedSourcePosition(generated2);
-			Assert.AreEqual(0, rootMapping.OriginalSourcePosition.CompareTo(childMapping.OriginalSourcePosition));
+			Assert.Equal(0, rootMapping.OriginalSourcePosition.CompareTo(childMapping.OriginalSourcePosition));
 		}
 
-		[TestMethod]
+		[Fact]
 		public void ApplyMap_PartialMatchingSources_ReturnsCorrectMap()
 		{
             // Expect mappings with same source filename as the applied source-map to be replaced
@@ -309,16 +308,16 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 			SourceMap combinedMap = parentMap.ApplySourceMap(childMap);
 
 			// Assert
-			Assert.IsNotNull(combinedMap);
-			Assert.AreEqual(2, combinedMap.ParsedMappings.Count);
-			Assert.AreEqual(2, combinedMap.Sources.Count);
+			Assert.NotNull(combinedMap);
+			Assert.Equal(2, combinedMap.ParsedMappings.Count);
+			Assert.Equal(2, combinedMap.Sources.Count);
 			MappingEntry firstCombinedMapping = combinedMap.GetMappingEntryForGeneratedSourcePosition(generated3);
-			Assert.IsTrue(firstCombinedMapping.IsValueEqual(mapping2));
+			Assert.True(firstCombinedMapping.IsValueEqual(mapping2));
 			MappingEntry secondCombinedMapping = combinedMap.GetMappingEntryForGeneratedSourcePosition(generated2);
-			Assert.AreEqual(0, secondCombinedMapping.OriginalSourcePosition.CompareTo(childMapping.OriginalSourcePosition));
+			Assert.Equal(0, secondCombinedMapping.OriginalSourcePosition.CompareTo(childMapping.OriginalSourcePosition));
 		}
 
-		[TestMethod]
+		[Fact]
 		public void ApplyMap_ExactMatchDeep_ReturnsCorrectMappingEntry()
 		{
 			// Arrange
@@ -359,11 +358,11 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 			SourceMap firstCombinedMap = parentMap.ApplySourceMap(childMap);
 
 			// Assert
-			Assert.IsNotNull(firstCombinedMap);
+			Assert.NotNull(firstCombinedMap);
 			SourceMap secondCombinedMap = firstCombinedMap.ApplySourceMap(grandChildMap);
-			Assert.IsNotNull(secondCombinedMap);
+			Assert.NotNull(secondCombinedMap);
 			MappingEntry rootMapping = secondCombinedMap.GetMappingEntryForGeneratedSourcePosition(generated3);
-			Assert.AreEqual(0, rootMapping.OriginalSourcePosition.CompareTo(mapLevel2.OriginalSourcePosition));
+			Assert.Equal(0, rootMapping.OriginalSourcePosition.CompareTo(mapLevel2.OriginalSourcePosition));
 		}
     }
 }

--- a/tests/SourcemapToolkit.SourcemapParser.UnitTests/SourcePositionUnitTests.cs
+++ b/tests/SourcemapToolkit.SourcemapParser.UnitTests/SourcePositionUnitTests.cs
@@ -1,11 +1,11 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Xunit;
 
 namespace SourcemapToolkit.SourcemapParser.UnitTests
 {
-	[TestClass]
+
 	public class SourcePositionUnitTests
 	{
-		[TestMethod]
+		[Fact]
 		public void CompareTo_SameLineAndColumn_Equal()
 		{
 			// Arrange
@@ -24,10 +24,10 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 			int result = x.CompareTo(y);
 
 			// Assert
-			Assert.AreEqual(0, result);
+			Assert.Equal(0, result);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void CompareTo_LargerZeroBasedLineNumber_ReturnLarger()
 		{
 			// Arrange
@@ -46,10 +46,10 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 			int result = x.CompareTo(y);
 
 			// Assert
-			Assert.IsTrue(result > 0);
+			Assert.True(result > 0);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void CompareTo_SmallerZeroBasedLineNumber_ReturnSmaller()
 		{
 			// Arrange
@@ -68,10 +68,10 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 			int result = x.CompareTo(y);
 
 			// Assert
-			Assert.IsTrue(result < 0);
+			Assert.True(result < 0);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void CompareTo_SameLineLargerColumn_ReturnLarger()
 		{
 			// Arrange
@@ -90,10 +90,10 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 			int result = x.CompareTo(y);
 
 			// Assert
-			Assert.IsTrue(result > 0);
+			Assert.True(result > 0);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void CompareTo_SameLineSmallerColumn_ReturnSmaller()
 		{
 			// Arrange
@@ -112,10 +112,10 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 			int result = x.CompareTo(y);
 
 			// Assert
-			Assert.IsTrue(result < 0);
+			Assert.True(result < 0);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void LessThanOverload_SameZeroBasedLineNumberXColumnSmaller_ReturnTrue()
 		{
 			// Arrange
@@ -134,10 +134,10 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 			bool result = x < y;
 
 			// Assert
-			Assert.IsTrue(result);
+			Assert.True(result);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void LessThanOverload_XZeroBasedLineNumberSmallerX_ReturnTrue()
 		{
 			// Arrange
@@ -156,10 +156,10 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 			bool result = x < y;
 
 			// Assert
-			Assert.IsTrue(result);
+			Assert.True(result);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void LessThanOverload_Equal_ReturnFalse()
 		{
 			// Arrange
@@ -178,10 +178,10 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 			bool result = x < y;
 
 			// Assert
-			Assert.IsFalse(result);
+			Assert.False(result);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void LessThanOverload_XColumnLarger_ReturnFalse()
 		{
 			// Arrange
@@ -200,10 +200,10 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 			bool result = x < y;
 
 			// Assert
-			Assert.IsFalse(result);
+			Assert.False(result);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void GreaterThanOverload_SameLineXColumnLarger_ReturnTrue()
 		{
 			// Arrange
@@ -222,10 +222,10 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 			bool result = x > y;
 
 			// Assert
-			Assert.IsTrue(result);
+			Assert.True(result);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void GreaterThanOverload_XZeroBasedLineNumberLarger_ReturnTrue()
 		{
 			// Arrange
@@ -244,10 +244,10 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 			bool result = x > y;
 
 			// Assert
-			Assert.IsTrue(result);
+			Assert.True(result);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void GreaterThanOverload_Equal_ReturnFalse()
 		{
 			// Arrange
@@ -266,10 +266,10 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 			bool result = x > y;
 
 			// Assert
-			Assert.IsFalse(result);
+			Assert.False(result);
 		}
 
-		[TestMethod]
+		[Fact]
 		public void GreaterThanOverload_XSmaller_ReturnFalse()
 		{
 			// Arrange
@@ -288,10 +288,10 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 			bool result = x > y;
 
 			// Assert
-			Assert.IsFalse(result);
+			Assert.False(result);
 		}
 
-        [TestMethod]
+        [Fact]
         public void IsEqualish_XEqualsY_ReturnTrue()
         {
             // Arrange
@@ -310,10 +310,10 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
             bool result = x.IsEqualish(y);
 
             // Assert
-            Assert.IsTrue(result);
+            Assert.True(result);
         }
 
-        [TestMethod]
+        [Fact]
         public void IsEqualish_XColumnNumberBiggerByOne_ReturnTrue()
         {
             // Arrange
@@ -332,10 +332,10 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
             bool result = x.IsEqualish(y);
 
             // Assert
-            Assert.IsTrue(result);
+            Assert.True(result);
         }
 
-        [TestMethod]
+        [Fact]
         public void IsEqualish_YColumnNumberBiggerByOne_ReturnTrue()
         {
             // Arrange
@@ -354,10 +354,10 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
             bool result = x.IsEqualish(y);
 
             // Assert
-            Assert.IsTrue(result);
+            Assert.True(result);
         }
 
-        [TestMethod]
+        [Fact]
         public void IsEqualish_YColumnNumberBiggerByTwo_ReturnFalse()
         {
             // Arrange
@@ -376,10 +376,10 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
             bool result = x.IsEqualish(y);
 
             // Assert
-            Assert.IsFalse(result);
+            Assert.False(result);
         }
 
-        [TestMethod]
+        [Fact]
         public void IsEqualish_XColumnNumberZeroLineNumbersDifferByOne_ReturnTrue()
         {
             // Arrange
@@ -398,10 +398,10 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
             bool result = x.IsEqualish(y);
 
             // Assert
-            Assert.IsTrue(result);
+            Assert.True(result);
         }
 
-        [TestMethod]
+        [Fact]
         public void IsEqualish_YColumnNumberZeroLineNumbersDifferByOne_ReturnTrue()
         {
             // Arrange
@@ -420,10 +420,10 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
             bool result = x.IsEqualish(y);
 
             // Assert
-            Assert.IsTrue(result);
+            Assert.True(result);
         }
 
-        [TestMethod]
+        [Fact]
         public void IsEqualish_YColumnNumberZeroLineNumbersDifferByTwo_ReturnFalse()
         {
             // Arrange
@@ -442,7 +442,7 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
             bool result = x.IsEqualish(y);
 
             // Assert
-            Assert.IsFalse(result);
+            Assert.False(result);
         }
     }
 }

--- a/tests/SourcemapToolkit.SourcemapParser.UnitTests/SourcemapToolkit.SourcemapParser.UnitTests.csproj
+++ b/tests/SourcemapToolkit.SourcemapParser.UnitTests/SourcemapToolkit.SourcemapParser.UnitTests.csproj
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props')" />
+  <Import Project="..\..\packages\xunit.core.2.4.1\build\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.4.1\build\xunit.core.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -41,11 +43,35 @@
     <AssemblyOriginatorKeyFile>..\..\SourceMapToolkit.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\..\packages\MSTest.TestFramework.1.1.17\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\..\packages\MSTest.TestFramework.1.1.17\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
+      <HintPath>..\..\packages\xunit.abstractions.2.0.3\lib\net35\xunit.abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.assert, Version=2.4.1.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
+      <HintPath>..\..\packages\xunit.assert.2.4.1\lib\netstandard1.1\xunit.assert.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.core, Version=2.4.1.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
+      <HintPath>..\..\packages\xunit.extensibility.core.2.4.1\lib\net452\xunit.core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.execution.desktop, Version=2.4.1.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
+      <HintPath>..\..\packages\xunit.extensibility.execution.2.4.1\lib\net452\xunit.execution.desktop.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
   </ItemGroup>
   <Choose>
     <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
@@ -91,6 +117,12 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\..\packages\xunit.analyzers.0.10.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
+  </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
       <ItemGroup>
@@ -111,6 +143,15 @@
   </Choose>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105.The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\xunit.core.2.4.1\build\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.4.1\build\xunit.core.props'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.core.2.4.1\build\xunit.core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.4.1\build\xunit.core.targets'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props'))" />
+  </Target>
+  <Import Project="..\..\packages\xunit.core.2.4.1\build\xunit.core.targets" Condition="Exists('..\..\packages\xunit.core.2.4.1\build\xunit.core.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/tests/SourcemapToolkit.SourcemapParser.UnitTests/packages.config
+++ b/tests/SourcemapToolkit.SourcemapParser.UnitTests/packages.config
@@ -1,8 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.UnitTestFramework.Extensions" version="2.0.0" targetFramework="net452" />
   <package id="MSTest.TestFramework" version="1.1.17" targetFramework="net452" />
-  <package id="RhinoMocks" version="3.6.1" targetFramework="net452" />
   <package id="System.Diagnostics.Contracts" version="4.0.1" targetFramework="net452" />
   <package id="xunit" version="2.4.1" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.3" targetFramework="net452" />


### PR DESCRIPTION
Important note: I was unable to run CallstackDeminifier tests in
paralell. This points to some technical dept that should be handled in
the future at least. See StackFrameDeminifierUnitTests.cs for assembly
configuration of xunit.

fixes #69