### PR TITLE
StackTraceParser: Support StackTraces with 'http' but without the parentheses

### DIFF
--- a/src/SourceMapToolkit.CallstackDeminifier/StackTraceParser.cs
+++ b/src/SourceMapToolkit.CallstackDeminifier/StackTraceParser.cs
@@ -97,6 +97,12 @@ namespace SourcemapToolkit.CallstackDeminifier
 				{
 					return frame.Substring(atStringIndex, httpIndex - atStringIndex).Replace("at ", "").Trim();
 				}
+
+				httpIndex = frame.IndexOf(" http", atStringIndex, StringComparison.Ordinal);
+				if (httpIndex != -1)
+				{
+					return frame.Substring(atStringIndex, httpIndex - atStringIndex).Replace("at ", "").Trim();
+				}
 			}
 
 			return null;

--- a/src/SourceMapToolkit.CallstackDeminifier/StackTraceParser.cs
+++ b/src/SourceMapToolkit.CallstackDeminifier/StackTraceParser.cs
@@ -100,12 +100,20 @@ namespace SourcemapToolkit.CallstackDeminifier
 					{
 						httpIndex = frame.IndexOf(" http", atStringIndex, StringComparison.Ordinal);
 						if (httpIndex != -1)
-							httpIndex++;		// append one char to include a blank space to be able to replace "at " correctly
+							httpIndex++;        // append one char to include a blank space to be able to replace "at " correctly
 					}
 
 					if (httpIndex != -1)
 					{
 						methodName = frame.Substring(atStringIndex, httpIndex - atStringIndex).Replace("at ", "").Trim();
+					}
+					else
+					{
+						var parenthesesIndex = frame.IndexOf(" (", atStringIndex, StringComparison.Ordinal);
+						if (parenthesesIndex != -1)
+						{
+							methodName = frame.Substring(atStringIndex, parenthesesIndex - atStringIndex).Replace("at ", "").Trim();
+						}
 					}
 				}
 			}

--- a/src/SourceMapToolkit.CallstackDeminifier/StackTraceParser.cs
+++ b/src/SourceMapToolkit.CallstackDeminifier/StackTraceParser.cs
@@ -101,6 +101,7 @@ namespace SourcemapToolkit.CallstackDeminifier
 				httpIndex = frame.IndexOf(" http", atStringIndex, StringComparison.Ordinal);
 				if (httpIndex != -1)
 				{
+					httpIndex++;		// append one char to include a blank space to be able to replace "at " correctly
 					return frame.Substring(atStringIndex, httpIndex - atStringIndex).Replace("at ", "").Trim();
 				}
 			}

--- a/tests/SourcemapToolkit.CallstackDeminifier.UnitTests/StackTraceParserUnitTests.cs
+++ b/tests/SourcemapToolkit.CallstackDeminifier.UnitTests/StackTraceParserUnitTests.cs
@@ -113,6 +113,23 @@ window.onload/<@http://localhost:19220/crashcauser.min.js:1:332";
 		}
 
 		[Fact]
+		public void TryParseSingleStackFrame_StackFrameWithWebpackLink_CorrectStackFrame()
+		{
+			// Arrange
+			StackTraceParser stackTraceParser = new StackTraceParser();
+			string frame = "    at eval (webpack-internal:///./Static/jsx/InitialStep/InitialStepForm.js:167:14)";
+
+			// Act
+			StackFrame result = stackTraceParser.TryParseSingleStackFrame(frame);
+
+			// Assert
+			Assert.Equal("webpack-internal:///./Static/jsx/InitialStep/InitialStepForm.js", result.FilePath);
+			Assert.Equal("eval", result.MethodName);
+			Assert.Equal(167-1, result.SourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(14-1, result.SourcePosition.ZeroBasedColumnNumber);
+		}
+
+		[Fact]
 		public void TryParseSingleStackFrame_StackFrameWithoutParentheses_CorrectStackFrame()
 		{
 			// Arrange

--- a/tests/SourcemapToolkit.CallstackDeminifier.UnitTests/StackTraceParserUnitTests.cs
+++ b/tests/SourcemapToolkit.CallstackDeminifier.UnitTests/StackTraceParserUnitTests.cs
@@ -113,6 +113,23 @@ window.onload/<@http://localhost:19220/crashcauser.min.js:1:332";
 		}
 
 		[Fact]
+		public void TryParseSingleStackFrame_StackFrameWithoutParentheses_CorrectStackFrame()
+		{
+			// Arrange
+			StackTraceParser stackTraceParser = new StackTraceParser();
+			string frame = "    at c http://localhost:19220/crashcauser.min.js:8:3";
+
+			// Act
+			StackFrame result = stackTraceParser.TryParseSingleStackFrame(frame);
+
+			// Assert
+			Assert.Equal("http://localhost:19220/crashcauser.min.js", result.FilePath);
+			Assert.Equal("c", result.MethodName);
+			Assert.Equal(7, result.SourcePosition.ZeroBasedLineNumber);
+			Assert.Equal(2, result.SourcePosition.ZeroBasedColumnNumber);
+		}
+
+		[Fact]
 		public void TryParseSingleStackFrame_ChromeStackFrame_CorrectStackFrame()
 		{
 			// Arrange


### PR DESCRIPTION
Support for stacktraces without parentheses for the http filename