### PR TITLE
Move function names by 1

### DIFF
--- a/src/SourceMapToolkit.CallstackDeminifier/StackTraceDeminifier.cs
+++ b/src/SourceMapToolkit.CallstackDeminifier/StackTraceDeminifier.cs
@@ -21,7 +21,11 @@ namespace SourcemapToolkit.CallstackDeminifier
 		/// <summary>
 		/// Parses and deminifies a string containing a minified stack trace.
 		/// </summary>
-		public DeminifyStackTraceResult DeminifyStackTrace(string stackTraceString, bool preferSourceMapsSymbols = false, bool fixOffByOne = false)
+		/// <param name="stackTraceString">stack trace as string, to deobfuscate</param>
+		/// <param name="preferSourceMapsSymbols">if true, we will use exact sourcemap names for deobfuscation, without guessing the wrapper function name from source code</param>
+		/// <param name="fixOffByOneWithPreferSouceMapSymbols">preferSourceMapsSymbols uses name at call site in deobfuscated frame. Passing this as true fixes that case, to use the caller function name from next frame</param>
+		/// <returns></returns>
+		public DeminifyStackTraceResult DeminifyStackTrace(string stackTraceString, bool preferSourceMapsSymbols = false, bool fixOffByOneWithPreferSouceMapSymbols = false)
 		{
 			var minifiedStackFrames = _stackTraceParser.ParseStackTrace(stackTraceString, out string message);
 			var deminifiedStackFrameResults = new List<StackFrameDeminificationResult>(minifiedStackFrames.Count);
@@ -37,7 +41,7 @@ namespace SourcemapToolkit.CallstackDeminifier
 			}
 
 			deminifiedStackFrameResults.Reverse();
-			if (fixOffByOne)
+			if (preferSourceMapsSymbols && fixOffByOneWithPreferSouceMapSymbols)
 			{
 				// we want to move all method names by one frame, so each frame will contain caller name and not callee name. To make callstacks more familiar to C# and js debug versions.
 				// However, for first frame we want to keep calee name (if avaliable) as well since this is interesting info we don't want to lose.

--- a/src/SourceMapToolkit.CallstackDeminifier/StackTraceDeminifier.cs
+++ b/src/SourceMapToolkit.CallstackDeminifier/StackTraceDeminifier.cs
@@ -21,7 +21,7 @@ namespace SourcemapToolkit.CallstackDeminifier
 		/// <summary>
 		/// Parses and deminifies a string containing a minified stack trace.
 		/// </summary>
-		public DeminifyStackTraceResult DeminifyStackTrace(string stackTraceString, bool preferSourceMapsSymbols = false)
+		public DeminifyStackTraceResult DeminifyStackTrace(string stackTraceString, bool preferSourceMapsSymbols = false, bool fixOffByOne = false)
 		{
 			var minifiedStackFrames = _stackTraceParser.ParseStackTrace(stackTraceString, out string message);
 			var deminifiedStackFrameResults = new List<StackFrameDeminificationResult>(minifiedStackFrames.Count);
@@ -37,7 +37,26 @@ namespace SourcemapToolkit.CallstackDeminifier
 			}
 
 			deminifiedStackFrameResults.Reverse();
-
+			if (fixOffByOne)
+			{
+				// we want to move all method names by one frame, so each frame will contain caller name and not callee name. To make callstacks more familiar to C# and js debug versions.
+				// However, for first frame we want to keep calee name (if avaliable) as well since this is interesting info we don't want to lose.
+				// However it means that for last frame (N), if have more then 1 frame in callstack, N-1 frame will have the same name.
+				// It is confusing, so lets replace last one with null. This will cause toString to use the obfuscated name
+				for (int i = 0; i < deminifiedStackFrameResults.Count - 1; i++)
+				{
+					string updatedMethodName = deminifiedStackFrameResults[i + 1].DeminifiedStackFrame.MethodName;
+					if (i == 0 && deminifiedStackFrameResults[i].DeminifiedStackFrame.MethodName != null)
+					{
+						updatedMethodName = updatedMethodName + "=>" + deminifiedStackFrameResults[i].DeminifiedStackFrame.MethodName;
+					}
+					deminifiedStackFrameResults[i].DeminifiedStackFrame.MethodName = updatedMethodName;
+				}
+				if (deminifiedStackFrameResults.Count > 1)
+				{
+					deminifiedStackFrameResults[deminifiedStackFrameResults.Count - 1].DeminifiedStackFrame.MethodName = null;
+				}
+			}
 			var result = new DeminifyStackTraceResult(message, minifiedStackFrames, deminifiedStackFrameResults);
 
 			return result;


### PR DESCRIPTION
Currently, in each frame the function name is a callee name, i.e the function that we are calling. Our developers and tools  expect it to be the caller function. to fix this, I am moving the deobfuscated method one frame up, with two exceptions\\
1. Will try to leave deobfuscated name in first frame, if exists.
2. Remove obfuscated name in last frame, since it is duplicated in N-1 frame and just creates confustion. 

Note that in this example, pollForCommandState is defined in RootPoller and not in ReactQueryCommandPoller as _before_ callstack suggests. Which is confusing

Before:
```
TypeError: Cannot read property '$commandHandlerManager$' of undefined
  at commandHandlerManager in webpack:///D$/Office/Build/x64/debug/biserver/ewajs/build/ts/objd/x64/dullscript/packages/biserver/src/EwaJs/CommandUI/QueryCommandManager.ts:768:25
  at handleRibbonQueryCommandForGrid in webpack:///D$/Office/Build/x64/debug/biserver/ewajs/build/ts/objd/x64/dullscript/packages/biserver/src/EwaJs/CommandUI/QueryCommandManager.ts:637:23
  at handleQueryCommand in webpack:///D$/Office/Build/x64/debug/biserver/ewajs/build/ts/objd/x64/dullscript/packages/biserver/src/EwaJs/RibbonManager.ts:862:39
  at handleQueryCommand in webpack:///D$/Office/Build/x64/debug/biserver/ewajs/build/ts/objd/x64/dullscript/packages/biserver/src/EwaJs/CommandUIManager.ts:274:18
  at executeRootCommand in webpack:///D$/Office/Build/x64/debug/biserver/ewajs/build/ts/objd/x64/dullscript/packages/biserver/src/EwaJs/ExcelReactRootUser.ts:85:29
  at executeRootCommand in webpack:///D$/Office/Build/x64/debug/biserver/ewajs/build/ts/objd/x64/dullscript/packages/msoserviceplatform/src/Ribbon/client/script/CUI/RootPoller.ts:61:18
  at pollForCommandState in webpack:///D$/Office/Build/x64/debug/biserver/ewajs/build/ts/objd/x64/dullscript/packages/msoserviceplatform/src/CommandUI/React/ReactQueryCommandPoller.ts:242:29
  at getPollResult in webpack:///D$/Office/Build/x64/debug/biserver/ewajs/build/ts/objd/x64/dullscript/packages/msoserviceplatform/src/CommandUI/React/ReactQueryCommandPoller.ts:56:31
  at getReduxActions in webpack:///D$/Office/Build/x64/debug/biserver/ewajs/build/ts/objd/x64/dullscript/packages/msoserviceplatform/src/CommandUI/React/ReactRibbonRootPoller.ts:286:58
  at getUpdateActionsForCommand in webpack:///D$/Office/Build/x64/debug/biserver/ewajs/build/ts/objd/x64/dullscript/packages/msoserviceplatform/src/CommandUI/React/ReactRibbonRootPoller.ts:241:14
```

After:
```
TypeError: Cannot read property '$commandHandlerManager$' of undefined
  at handleRibbonQueryCommandForGrid=>commandHandlerManager in webpack:///D$/Office/Build/x64/debug/biserver/ewajs/build/ts/objd/x64/dullscript/packages/biserver/src/EwaJs/CommandUI/QueryCommandManager.ts:768:25
  at handleQueryCommand in webpack:///D$/Office/Build/x64/debug/biserver/ewajs/build/ts/objd/x64/dullscript/packages/biserver/src/EwaJs/CommandUI/QueryCommandManager.ts:637:23
  at handleQueryCommand in webpack:///D$/Office/Build/x64/debug/biserver/ewajs/build/ts/objd/x64/dullscript/packages/biserver/src/EwaJs/RibbonManager.ts:862:39
  at executeRootCommand in webpack:///D$/Office/Build/x64/debug/biserver/ewajs/build/ts/objd/x64/dullscript/packages/biserver/src/EwaJs/CommandUIManager.ts:274:18
  at executeRootCommand in webpack:///D$/Office/Build/x64/debug/biserver/ewajs/build/ts/objd/x64/dullscript/packages/biserver/src/EwaJs/ExcelReactRootUser.ts:85:29
  at pollForCommandState in webpack:///D$/Office/Build/x64/debug/biserver/ewajs/build/ts/objd/x64/dullscript/packages/msoserviceplatform/src/Ribbon/client/script/CUI/RootPoller.ts:61:18
  at getPollResult in webpack:///D$/Office/Build/x64/debug/biserver/ewajs/build/ts/objd/x64/dullscript/packages/msoserviceplatform/src/CommandUI/React/ReactQueryCommandPoller.ts:242:29
  at getReduxActions in webpack:///D$/Office/Build/x64/debug/biserver/ewajs/build/ts/objd/x64/dullscript/packages/msoserviceplatform/src/CommandUI/React/ReactQueryCommandPoller.ts:56:31
  at getUpdateActionsForCommand in webpack:///D$/Office/Build/x64/debug/biserver/ewajs/build/ts/objd/x64/dullscript/packages/msoserviceplatform/src/CommandUI/React/ReactRibbonRootPoller.ts:286:58
  at $ReactRibbonRootPoller_ReactRibbonRootPoller$$.$getUpdateActionsForCommands$ in webpack:///D$/Office/Build/x64/debug/biserver/ewajs/build/ts/objd/x64/dullscript/packages/msoserviceplatform/src/CommandUI/React/ReactRibbonRootPoller.ts:241:14
```
