### PR TITLE
Remove "default" keyword usage

### DIFF
--- a/src/SourcemapToolkit.SourcemapParser/SourceMap.cs
+++ b/src/SourcemapToolkit.SourcemapParser/SourceMap.cs
@@ -181,7 +181,7 @@ namespace SourcemapToolkit.SourcemapParser
 			SourceMap newSourceMap = new SourceMap(
 				version: Version,
 				file: File,
-				mappings: default,
+				mappings: default(string),
 				sources: sources.ToList(),
 				names: names.ToList(),
 				parsedMappings: parsedMappings,

--- a/src/SourcemapToolkit.SourcemapParser/SourceMapGenerator.cs
+++ b/src/SourcemapToolkit.SourcemapParser/SourceMapGenerator.cs
@@ -16,12 +16,12 @@ namespace SourcemapToolkit.SourcemapParser
 		/// <summary>
 		/// Last location of the code in the transformed code
 		/// </summary>
-		public SourcePosition LastGeneratedPosition { get; private set; } = default;
+		public SourcePosition LastGeneratedPosition { get; private set; } = default(SourcePosition);
 
 		/// <summary>
 		/// Last location of the code in the source code
 		/// </summary>
-		public SourcePosition LastOriginalPosition { get; set; } = default;
+		public SourcePosition LastOriginalPosition { get; set; } = default(SourcePosition);
 
 		/// <summary>
 		/// List that contains the symbol names
@@ -117,7 +117,7 @@ namespace SourcemapToolkit.SourcemapParser
 				mappings: mappings,
 				sources: sourceMap.Sources,
 				names: sourceMap.Names,
-				parsedMappings: default,
+				parsedMappings: default(IReadOnlyList<MappingEntry>),
 				sourcesContent: sourceMap.SourcesContent);
 
 			return JsonConvert.SerializeObject(mapToSerialize,

--- a/tests/SourcemapToolkit.CallstackDeminifier.UnitTests/FunctionMapConsumerUnitTests.cs
+++ b/tests/SourcemapToolkit.CallstackDeminifier.UnitTests/FunctionMapConsumerUnitTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
-using Xunit;
 using SourcemapToolkit.SourcemapParser;
+using Xunit;
+
 
 namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 {
@@ -34,8 +35,8 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 			List<FunctionMapEntry> functionMap = new List<FunctionMapEntry>
 			{
 				new FunctionMapEntry(
-					bindings: default,
-					deminifiedMethodName: default,
+					bindings: default(IReadOnlyList<BindingInformation>),
+					deminifiedMethodName: default(string),
 					startSourcePosition: new SourcePosition(zeroBasedLineNumber: 40, zeroBasedColumnNumber: 10),
 					endSourcePosition: new SourcePosition(zeroBasedLineNumber: 50, zeroBasedColumnNumber: 10))
 				
@@ -57,8 +58,8 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 				zeroBasedLineNumber: 41,
 				zeroBasedColumnNumber: 2);
 			FunctionMapEntry functionMapEntry = new FunctionMapEntry(
-				bindings: default,
-				deminifiedMethodName: default,
+				bindings: default(IReadOnlyList<BindingInformation>),
+				deminifiedMethodName: default(string),
 				startSourcePosition: new SourcePosition(zeroBasedLineNumber: 40, zeroBasedColumnNumber: 10),
 				endSourcePosition: new SourcePosition(zeroBasedLineNumber: 50, zeroBasedColumnNumber: 10));
 			List<FunctionMapEntry> functionMap = new List<FunctionMapEntry>
@@ -82,13 +83,13 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 				zeroBasedLineNumber: 31,
 				zeroBasedColumnNumber: 0);
 			FunctionMapEntry functionMapEntry = new FunctionMapEntry(
-				bindings: default,
-				deminifiedMethodName: default,
+				bindings: default(IReadOnlyList<BindingInformation>),
+				deminifiedMethodName: default(string),
 				startSourcePosition: new SourcePosition(zeroBasedLineNumber: 10, zeroBasedColumnNumber: 10),
 				endSourcePosition: new SourcePosition(zeroBasedLineNumber: 20, zeroBasedColumnNumber: 30));
 			FunctionMapEntry functionMapEntry2 = new FunctionMapEntry(
-				bindings: default,
-				deminifiedMethodName: default,
+				bindings: default(IReadOnlyList<BindingInformation>),
+				deminifiedMethodName: default(string),
 				startSourcePosition: new SourcePosition(zeroBasedLineNumber: 30, zeroBasedColumnNumber: 0),
 				endSourcePosition: new SourcePosition(zeroBasedLineNumber: 40, zeroBasedColumnNumber: 2));
 			List<FunctionMapEntry> functionMap = new List<FunctionMapEntry>
@@ -113,13 +114,13 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 				zeroBasedLineNumber: 10,
 				zeroBasedColumnNumber: 25);
 			FunctionMapEntry functionMapEntry = new FunctionMapEntry(
-				bindings: default,
-				deminifiedMethodName: default,
+				bindings: default(IReadOnlyList<BindingInformation>),
+				deminifiedMethodName: default(string),
 				startSourcePosition: new SourcePosition(zeroBasedLineNumber: 5, zeroBasedColumnNumber: 10),
 				endSourcePosition: new SourcePosition(zeroBasedLineNumber: 20, zeroBasedColumnNumber: 30));
 			FunctionMapEntry functionMapEntry2 = new FunctionMapEntry(
-				bindings: default,
-				deminifiedMethodName: default,
+				bindings: default(IReadOnlyList<BindingInformation>),
+				deminifiedMethodName: default(string),
 				startSourcePosition: new SourcePosition(zeroBasedLineNumber: 9, zeroBasedColumnNumber: 0),
 				endSourcePosition: new SourcePosition(zeroBasedLineNumber: 15, zeroBasedColumnNumber: 2));
 			List<FunctionMapEntry> functionMap = new List<FunctionMapEntry>

--- a/tests/SourcemapToolkit.CallstackDeminifier.UnitTests/SourceMapExtensionsUnitTests.cs
+++ b/tests/SourcemapToolkit.CallstackDeminifier.UnitTests/SourceMapExtensionsUnitTests.cs
@@ -58,7 +58,7 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 			List<BindingInformation> bindings = new List<BindingInformation>()
 				{
 					new BindingInformation(
-						name: default,
+						name: default(string),
 						sourcePosition: new SourcePosition(zeroBasedLineNumber: 20, zeroBasedColumnNumber: 15))
 				};
 
@@ -80,7 +80,7 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 			List<BindingInformation> bindings = new List<BindingInformation>()
 				{
 					new BindingInformation(
-						name: default,
+						name: default(string),
 						sourcePosition: new SourcePosition(zeroBasedLineNumber: 5, zeroBasedColumnNumber: 8))
 				};
 
@@ -89,7 +89,7 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 				x =>
 					x.GetMappingEntryForGeneratedSourcePosition(
 						Arg<SourcePosition>.Matches(y => y.ZeroBasedLineNumber == 5 && y.ZeroBasedColumnNumber == 8)))
-				.Return(new MappingEntry(generatedSourcePosition: default, originalName: "foo"));
+				.Return(new MappingEntry(generatedSourcePosition: default(SourcePosition), originalName: "foo"));
 
 			// Act
 			string result = SourceMapExtensions.GetDeminifiedMethodName(sourceMap, bindings);
@@ -106,10 +106,10 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 			List<BindingInformation> bindings = new List<BindingInformation>
 				{
 					new BindingInformation(
-						name: default,
+						name: default(string),
 						sourcePosition: new SourcePosition(zeroBasedLineNumber: 86, zeroBasedColumnNumber: 52)),
 					new BindingInformation(
-						name: default,
+						name: default(string),
 						sourcePosition: new SourcePosition(zeroBasedLineNumber: 88, zeroBasedColumnNumber: 78))
 				};
 
@@ -124,7 +124,7 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 				x =>
 					x.GetMappingEntryForGeneratedSourcePosition(
 						Arg<SourcePosition>.Matches(y => y.ZeroBasedLineNumber == 88 && y.ZeroBasedColumnNumber == 78)))
-				.Return(new MappingEntry(generatedSourcePosition: default, originalName: "baz"));
+				.Return(new MappingEntry(generatedSourcePosition: default(SourcePosition), originalName: "baz"));
 
 			// Act
 			string result = SourceMapExtensions.GetDeminifiedMethodName(sourceMap, bindings);
@@ -141,10 +141,10 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 			List<BindingInformation> bindings = new List<BindingInformation>
 				{
 					new BindingInformation(
-						name: default,
+						name: default(string),
 						sourcePosition: new SourcePosition(zeroBasedLineNumber: 5, zeroBasedColumnNumber: 5)),
 					new BindingInformation(
-						name: default,
+						name: default(string),
 						sourcePosition: new SourcePosition(zeroBasedLineNumber: 20, zeroBasedColumnNumber: 10))
 				};
 
@@ -153,13 +153,13 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 				x =>
 					x.GetMappingEntryForGeneratedSourcePosition(
 						Arg<SourcePosition>.Matches(y => y.ZeroBasedLineNumber == 5 && y.ZeroBasedColumnNumber == 5)))
-				.Return(new MappingEntry(generatedSourcePosition: default, originalName: "bar"));
+				.Return(new MappingEntry(generatedSourcePosition: default(SourcePosition), originalName: "bar"));
 
 			sourceMap.Stub(
 				x =>
 					x.GetMappingEntryForGeneratedSourcePosition(
 						Arg<SourcePosition>.Matches(y => y.ZeroBasedLineNumber == 20 && y.ZeroBasedColumnNumber == 10)))
-				.Return(new MappingEntry(generatedSourcePosition: default, originalName: "baz"));
+				.Return(new MappingEntry(generatedSourcePosition: default(SourcePosition), originalName: "baz"));
 
 			// Act
 			string result = SourceMapExtensions.GetDeminifiedMethodName(sourceMap, bindings);

--- a/tests/SourcemapToolkit.CallstackDeminifier.UnitTests/StackFrameDeminifierUnitTests.cs
+++ b/tests/SourcemapToolkit.CallstackDeminifier.UnitTests/StackFrameDeminifierUnitTests.cs
@@ -226,22 +226,22 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 		private static FunctionMapEntry CreateFunctionMapEntry(string deminifiedMethodName)
 		{
 			return new FunctionMapEntry(
-				bindings: default,
+				bindings: default(IReadOnlyList<BindingInformation>),
 				deminifiedMethodName,
-				startSourcePosition: default,
-				endSourcePosition: default);
+				startSourcePosition: default(SourcePosition),
+				endSourcePosition: default(SourcePosition);
 		}
 
-		private static SourceMap CreateSourceMap(List<MappingEntry> parsedMappings = default)
+		private static SourceMap CreateSourceMap(List<MappingEntry> parsedMappings = default(List<MappingEntry>))
 		{
 			return new SourceMap(
-				version: default,
-				file: default,
-				mappings: default,
-				sources: default,
-				names: default,
+				version: default(int),
+				file: default(string),
+				mappings: default(string),
+				sources: default(IReadOnlyList<string>),
+				names: default(IReadOnlyList<string>),
 				parsedMappings: parsedMappings,
-				sourcesContent: default);
+				sourcesContent: default(IReadOnlyList<string>));
 		}
 	}
 }

--- a/tests/SourcemapToolkit.SourcemapParser.UnitTests/SourceMapGeneratorUnitTests.cs
+++ b/tests/SourcemapToolkit.SourcemapParser.UnitTests/SourceMapGeneratorUnitTests.cs
@@ -171,11 +171,11 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 			SourceMap input = new SourceMap(
 				version: 3,
 				file: "CommonIntl",
-				mappings: default,
+				mappings: default(string),
 				sources: sources,
 				names: names,
 				parsedMappings: parsedMappings,
-				sourcesContent: default);
+				sourcesContent: default(IReadOnlyList<string>));
 
 			return input;
 		}

--- a/tests/SourcemapToolkit.SourcemapParser.UnitTests/SourceMapTransformerUnitTests.cs
+++ b/tests/SourcemapToolkit.SourcemapParser.UnitTests/SourceMapTransformerUnitTests.cs
@@ -19,11 +19,11 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 			MappingEntry mappingEntry = UnitTestUtils.getSimpleEntry(generated1, original1, "sourceOne.js");
 
 			SourceMap map = new SourceMap(
-				version: default,
+				version: default(int),
 				file: "generated.js",
-				mappings: default,
+				mappings: default(string),
 				sources: new List<string>() { "sourceOne.js" },
-				names: default,
+				names: default(IReadOnlyList<string>),
 				parsedMappings: new List<MappingEntry> { mappingEntry },
 				sourcesContent: new List<string> { "var a = b" });
 
@@ -54,11 +54,11 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 			MappingEntry mappingEntry2 = UnitTestUtils.getSimpleEntry(generated2, original2, "sourceOne.js");
 
 			SourceMap map = new SourceMap(
-				version: default,
+				version: default(int),
 				file: "generated.js",
-				mappings: default,
+				mappings: default(string),
 				sources: new List<string>() { "sourceOne.js" },
-				names: default,
+				names: default(IReadOnlyList<string>),
 				parsedMappings: new List<MappingEntry> { mappingEntry, mappingEntry2 },
 				sourcesContent: new List<string> { "var a = b" });
 
@@ -89,11 +89,11 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 			MappingEntry mappingEntry2 = UnitTestUtils.getSimpleEntry(generated2, original2, "sourceOne.js");
 
 			SourceMap map = new SourceMap(
-				version: default,
+				version: default(int),
 				file: "generated.js",
-				mappings: default,
+				mappings: default(string),
 				sources: new List<string>() { "sourceOne.js" },
-				names: default,
+				names: default(IReadOnlyList<string>),
 				parsedMappings: new List<MappingEntry> { mappingEntry, mappingEntry2 },
 				sourcesContent: new List<string> { "var a = b" });
 

--- a/tests/SourcemapToolkit.SourcemapParser.UnitTests/SourceMapUnitTests.cs
+++ b/tests/SourcemapToolkit.SourcemapParser.UnitTests/SourceMapUnitTests.cs
@@ -328,13 +328,13 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 		}
 
 		private static SourceMap CreateSourceMap(
-			int version = default,
-			string file = default,
-			string mappings = default,
-			IReadOnlyList<string> sources = default,
-			IReadOnlyList<string> names = default,
-			IReadOnlyList<MappingEntry> parsedMappings = default,
-			IReadOnlyList<string> sourcesContent = default)
+			int version = default(int),
+			string file = default(string),
+			string mappings = default(string),
+			IReadOnlyList<string> sources = default(IReadOnlyList<string>),
+			IReadOnlyList<string> names = default(IReadOnlyList<string>),
+			IReadOnlyList<MappingEntry> parsedMappings = default(IReadOnlyList<MappingEntry>),
+			IReadOnlyList<string> sourcesContent = default(IReadOnlyList<string>))
 		{
 			return new SourceMap(
 				version: version,


### PR DESCRIPTION
Eliminate default since it is quicker than learning how to bump the C# runtime specified at build time in.  C# 7.0 didn't support `default` so migrating to `default(type)`.