### PR TITLE
Get rid of trailing unnamed parameters

### DIFF
--- a/src/SourcemapToolkit.SourcemapParser/SourceMap.cs
+++ b/src/SourcemapToolkit.SourcemapParser/SourceMap.cs
@@ -185,7 +185,7 @@ namespace SourcemapToolkit.SourcemapParser
 				sources: sources.ToList(),
 				names: names.ToList(),
 				parsedMappings: parsedMappings,
-				new List<string>());
+				sourcesContent: new List<string>());
 
 			return newSourceMap;
 		}


### PR DESCRIPTION
These are not supported in C# 7.0 so get rid of the first one causing a build failure.