### PR TITLE
add optional removeSourcesContent param

### DIFF
--- a/src/SourceMapToolkit.CallstackDeminifier/SourceMapStore.cs
+++ b/src/SourceMapToolkit.CallstackDeminifier/SourceMapStore.cs
@@ -16,10 +16,10 @@ namespace SourcemapToolkit.CallstackDeminifier
 		private readonly ISourceMapProvider _sourceMapProvider;
 		private readonly KeyValueCache<string, SourceMap> _sourceMapCache;
 
-		public SourceMapStore(ISourceMapProvider sourceMapProvider)
+		public SourceMapStore(ISourceMapProvider sourceMapProvider, bool removeSourcesContent)
 		{
 			_sourceMapProvider = sourceMapProvider;
-			_sourceMapParser = new SourceMapParser();
+			_sourceMapParser = new SourceMapParser(removeSourcesContent);
 			_sourceMapCache = new KeyValueCache<string, SourceMap>(sourceCodeUrl => _sourceMapParser.ParseSourceMap(_sourceMapProvider.GetSourceMapContentsForCallstackUrl(sourceCodeUrl)));
 		}
 

--- a/src/SourcemapToolkit.SourcemapParser/SourceMapParser.cs
+++ b/src/SourcemapToolkit.SourcemapParser/SourceMapParser.cs
@@ -8,10 +8,12 @@ namespace SourcemapToolkit.SourcemapParser
 	public class SourceMapParser
 	{
 		private readonly MappingsListParser _mappingsListParser;
+		private readonly bool _removeSourcesContent;
 
-		public SourceMapParser()
+		public SourceMapParser(bool removeSourcesContent = false)
 		{
 			_mappingsListParser = new MappingsListParser();
+			_removeSourcesContent = removeSourcesContent;
 		}
 
 		/// <summary>
@@ -36,7 +38,15 @@ namespace SourcemapToolkit.SourcemapParser
 				RemoveExtraSpaceFromList(parsedMappings);
 				RemoveExtraSpaceFromList(deserializedSourceMap.Sources);
 				RemoveExtraSpaceFromList(deserializedSourceMap.Names);
-				RemoveExtraSpaceFromList(deserializedSourceMap.SourcesContent);
+
+				if (_removeSourcesContent && deserializedSourceMap.SourcesContent != null)
+				{
+					deserializedSourceMap.SourcesContent.Clear();
+				}
+				else
+				{
+					RemoveExtraSpaceFromList(deserializedSourceMap.SourcesContent);
+				}
 
 				SourceMap result = new SourceMap(
 					version: deserializedSourceMap.Version,

--- a/tests/SourcemapToolkit.CallstackDeminifier.UnitTests/StackTraceDeminifierClosureEndToEndTests.cs
+++ b/tests/SourcemapToolkit.CallstackDeminifier.UnitTests/StackTraceDeminifierClosureEndToEndTests.cs
@@ -20,7 +20,7 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 			ISourceCodeProvider sourceCodeProvider = MockRepository.GenerateStrictMock<ISourceCodeProvider>();
 			sourceCodeProvider.Stub(x => x.GetSourceCode("http://localhost:11323/closurecrashcauser.minified.js")).Return(UnitTestUtils.StreamReaderFromString(GeneratedCodeString));
 
-			return StackTraceDeminfierFactory.GetStackTraceDeminfier(sourceMapProvider, sourceCodeProvider);
+			return StackTraceDeminfierFactory.GetStackTraceDeminfier(sourceMapProvider, sourceCodeProvider, removeSourcesContent: true);
 		}
 
 		private void ValidateDeminifyStackTraceResults(DeminifyStackTraceResult results)

--- a/tests/SourcemapToolkit.CallstackDeminifier.UnitTests/StackTraceDeminifierEndToEndTests.cs
+++ b/tests/SourcemapToolkit.CallstackDeminifier.UnitTests/StackTraceDeminifierEndToEndTests.cs
@@ -19,7 +19,7 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 			ISourceCodeProvider sourceCodeProvider = MockRepository.GenerateStrictMock<ISourceCodeProvider>();
 			sourceCodeProvider.Stub(x => x.GetSourceCode("http://localhost:11323/crashcauser.min.js")).Return(UnitTestUtils.StreamReaderFromString(GeneratedCodeString));
 
-            return StackTraceDeminfierFactory.GetStackTraceDeminfier(sourceMapProvider, sourceCodeProvider);
+            return StackTraceDeminfierFactory.GetStackTraceDeminfier(sourceMapProvider, sourceCodeProvider, removeSourcesContent: true);
         }
 
 		private static void ValidateDeminifyStackTraceResults(DeminifyStackTraceResult results)

--- a/tests/SourcemapToolkit.SourcemapParser.UnitTests/SourceMapParserUnitTests.cs
+++ b/tests/SourcemapToolkit.SourcemapParser.UnitTests/SourceMapParserUnitTests.cs
@@ -40,5 +40,26 @@ namespace SourcemapToolkit.SourcemapParser.UnitTests
 			Assert.Equal("CommonStrings", output.Names[0]);
 			Assert.Equal("afrikaans", output.Names[1]);
 		}
+
+		[Fact]
+		public void ParseSourceMap_SimpleSourceMapWithRemovedSourcesContent_CorrectlyParsed()
+		{
+			// Arrange
+			SourceMapParser sourceMapParser = new SourceMapParser(removeSourcesContent: true);
+			string input = "{ \"version\":3, \"file\":\"CommonIntl\", \"lineCount\":65, \"mappings\":\"AACAA,aAAA,CAAc\", \"sources\":[\"input/CommonIntl.js\"], \"names\":[\"CommonStrings\",\"afrikaans\"], \"sourcescontent\":[\"CommonStrings.afrikaans(test)...\"]}";
+
+			// Act
+			SourceMap output = sourceMapParser.ParseSourceMap(UnitTestUtils.StreamReaderFromString(input));
+
+			// Assert
+			Assert.Equal(3, output.Version);
+			Assert.Equal("CommonIntl", output.File);
+			Assert.Equal("AACAA,aAAA,CAAc", output.Mappings);
+			Assert.Single(output.Sources);
+			Assert.Equal("input/CommonIntl.js", output.Sources[0]);
+			Assert.Equal(2, output.Names.Count);
+			Assert.Equal("CommonStrings", output.Names[0]);
+			Assert.Equal("afrikaans", output.Names[1]);
+		}
 	}
 }


### PR DESCRIPTION
Optional parameter that will remove "SourcesContent" data from the loaded source maps, which will use less memory for the cached map files
