### PR TITLE
external IKeyValueCache

### DIFF
--- a/src/SourceMapToolkit.CallstackDeminifier/KeyValueCache.cs
+++ b/src/SourceMapToolkit.CallstackDeminifier/KeyValueCache.cs
@@ -3,10 +3,24 @@ using System.Collections.Concurrent;
 
 namespace SourcemapToolkit.CallstackDeminifier
 {
-	internal class KeyValueCache<TKey, TValue> where TValue : class
+	public interface IKeyValueCache<TKey, TValue> where TValue : class
+	{
+		/// <summary>
+		/// Attempts to obtain the value associated with this key.
+		/// </summary>
+		TValue GetValue(TKey key);
+
+
+		/// <summary>
+		/// Set\Change the valueGetter function which returns a new value for given key.
+		/// </summary>
+		void SetValueGetter(Func<TKey, TValue> valueGetter);
+	}
+
+	internal class KeyValueCache<TKey, TValue> : IKeyValueCache<TKey, TValue> where TValue : class
 	{
 		private readonly ConcurrentDictionary<TKey, TValue> _cache;
-		private readonly Func<TKey, TValue> _valueGetter;
+		private Func<TKey, TValue> _valueGetter;
 		public KeyValueCache(Func<TKey, TValue> valueGetter)
 		{
 			_cache = new ConcurrentDictionary<TKey, TValue>();
@@ -34,6 +48,11 @@ namespace SourcemapToolkit.CallstackDeminifier
 			}
 
 			return value;
+		}
+
+		public void SetValueGetter(Func<TKey, TValue> valueGetter)
+		{
+			_valueGetter = valueGetter;
 		}
 	}
 }

--- a/src/SourceMapToolkit.CallstackDeminifier/StackTraceDeminfierFactory.cs
+++ b/src/SourceMapToolkit.CallstackDeminifier/StackTraceDeminfierFactory.cs
@@ -69,7 +69,7 @@ namespace SourcemapToolkit.CallstackDeminifier
 		/// This method gets external keyValueCache object, which holds the SourceMap per file, and will allow a better caching control for memory efficiency.
 		/// </summary>
 		/// <param name="sourceMapProvider">Consumers of the API should implement this interface, which provides the source map for a given JavaScript file. Throws ArgumentNullException if the parameter is set to null.</param>
-		/// <param name="keyValueCache">Object of type IKeyValueCache which will have map file name (string) ans key and returns the matching SourceMap as value</param>
+		/// <param name="keyValueCache">Object of type IKeyValueCache which will have map file name (string) as keys, and returns the matching SourceMap as value</param>
 		/// <param name="removeSourcesContent">Optional parameter that will remove "SourcesContent" data from the loaded source maps, which will use less memory for the cached map files</param>
 		public static StackTraceDeminifier GetMapOnlyStackTraceDeminfier(ISourceMapProvider sourceMapProvider, IKeyValueCache<string, SourceMap> keyValueCache, bool removeSourcesContent = false)
 		{
@@ -88,7 +88,7 @@ namespace SourcemapToolkit.CallstackDeminifier
 		/// </summary>
 		/// <param name="sourceMapProvider">Consumers of the API should implement this interface, which provides the source map for a given JavaScript file. Throws ArgumentNullException if the parameter is set to null.</param>
 		/// <param name="stackTraceParser">Consumers of the API should implement this interface, which provides a parser for the stacktrace. Throws ArgumentNullException if the parameter is set to null.</param>
-		/// <param name="keyValueCache">Optional object of type IKeyValueCache which will have map file name (string) ans key and returns the matching SourceMap as value</param>
+		/// <param name="keyValueCache">Optional object of type IKeyValueCache which will have map file name (string) as key, and returns the matching SourceMap as value</param>
 		/// <param name="removeSourcesContent">Optional parameter that will remove "SourcesContent" data from the loaded source maps, which will use less memory for the cached map files</param>
 		public static StackTraceDeminifier GetMapOnlyStackTraceDeminfier(ISourceMapProvider sourceMapProvider, IStackTraceParser stackTraceParser, IKeyValueCache<string, SourceMap> keyValueCache = null, bool removeSourcesContent = false)
 		{

--- a/src/SourceMapToolkit.CallstackDeminifier/StackTraceDeminfierFactory.cs
+++ b/src/SourceMapToolkit.CallstackDeminifier/StackTraceDeminfierFactory.cs
@@ -84,7 +84,6 @@ namespace SourcemapToolkit.CallstackDeminifier
 		/// <summary>
 		/// Creates a StackTraceDeminifier which does not depend on JS files, and is ES2015+ compatible.
 		/// StackTrace deminifiers created with this method will keep source maps cached, and thus use significantly more memory during runtime than the ones generated with GetMethodNameOnlyStackTraceDeminfier.
-		/// This method gets external keyValueCache object, which holds the SourceMap per file, and will allow a better caching control for memory efficiency.
 		/// </summary>
 		/// <param name="sourceMapProvider">Consumers of the API should implement this interface, which provides the source map for a given JavaScript file. Throws ArgumentNullException if the parameter is set to null.</param>
 		/// <param name="stackTraceParser">Consumers of the API should implement this interface, which provides a parser for the stacktrace. Throws ArgumentNullException if the parameter is set to null.</param>

--- a/src/SourceMapToolkit.CallstackDeminifier/StackTraceDeminfierFactory.cs
+++ b/src/SourceMapToolkit.CallstackDeminifier/StackTraceDeminfierFactory.cs
@@ -87,6 +87,7 @@ namespace SourcemapToolkit.CallstackDeminifier
 		/// This method gets external keyValueCache object, which holds the SourceMap per file, and will allow a better caching control for memory efficiency.
 		/// </summary>
 		/// <param name="sourceMapProvider">Consumers of the API should implement this interface, which provides the source map for a given JavaScript file. Throws ArgumentNullException if the parameter is set to null.</param>
+		/// <param name="stackTraceParser">Consumers of the API should implement this interface, which provides a parser for the stacktrace. Throws ArgumentNullException if the parameter is set to null.</param>
 		/// <param name="keyValueCache">Optional object of type IKeyValueCache which will have map file name (string) ans key and returns the matching SourceMap as value</param>
 		/// <param name="removeSourcesContent">Optional parameter that will remove "SourcesContent" data from the loaded source maps, which will use less memory for the cached map files</param>
 		public static StackTraceDeminifier GetMapOnlyStackTraceDeminfier(ISourceMapProvider sourceMapProvider, IStackTraceParser stackTraceParser, IKeyValueCache<string, SourceMap> keyValueCache = null, bool removeSourcesContent = false)

--- a/src/SourceMapToolkit.CallstackDeminifier/StackTraceDeminfierFactory.cs
+++ b/src/SourceMapToolkit.CallstackDeminifier/StackTraceDeminfierFactory.cs
@@ -73,11 +73,20 @@ namespace SourcemapToolkit.CallstackDeminifier
 		/// <param name="removeSourcesContent">Optional parameter that will remove "SourcesContent" data from the loaded source maps, which will use less memory for the cached map files</param>
 		public static StackTraceDeminifier GetMapOnlyStackTraceDeminfier(ISourceMapProvider sourceMapProvider, IKeyValueCache<string, SourceMap> keyValueCache, bool removeSourcesContent = false)
 		{
+			if (keyValueCache == null)
+			{
+				throw new ArgumentNullException(nameof(keyValueCache));
+			}
+			
 			return GetMapOnlyStackTraceDeminfier(sourceMapProvider, new StackTraceParser(), keyValueCache, removeSourcesContent);
-
 		}
 
-
+		/// <summary>
+		/// Creates a StackTraceDeminifier which does not depend on JS files, and is ES2015+ compatible.
+		/// StackTrace deminifiers created with this method will keep source maps cached, and thus use significantly more memory during runtime than the ones generated with GetMethodNameOnlyStackTraceDeminfier.
+		/// This method gets external keyValueCache object, which holds the SourceMap per file, and will allow a better caching control for memory efficiency.
+		/// </summary>
+		/// <param name="sourceMapProvider">Consumers of the API should implement this interface, which provides the source map for a given JavaScript file. Throws ArgumentNullException if the parameter is set to null.</param>
 		/// <param name="keyValueCache">Optional object of type IKeyValueCache which will have map file name (string) ans key and returns the matching SourceMap as value</param>
 		/// <param name="removeSourcesContent">Optional parameter that will remove "SourcesContent" data from the loaded source maps, which will use less memory for the cached map files</param>
 		public static StackTraceDeminifier GetMapOnlyStackTraceDeminfier(ISourceMapProvider sourceMapProvider, IStackTraceParser stackTraceParser, IKeyValueCache<string, SourceMap> keyValueCache = null, bool removeSourcesContent = false)

--- a/tests/SourcemapToolkit.CallstackDeminifier.UnitTests/KeyValueCacheUnitTests.cs
+++ b/tests/SourcemapToolkit.CallstackDeminifier.UnitTests/KeyValueCacheUnitTests.cs
@@ -13,7 +13,7 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 			// Arrange
 			Func<string, string> valueGetter = MockRepository.GenerateStrictMock<Func<string, string>>();
 			valueGetter.Stub(x => x("bar")).Return("foo");
-			KeyValueCache<string, string> keyValueCache = new KeyValueCache<string, string>(valueGetter);
+			IKeyValueCache<string, string> keyValueCache = new KeyValueCache<string, string>(valueGetter);
 
 			// Act
 			string result = keyValueCache.GetValue("bar");
@@ -29,7 +29,7 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 			// Arrange
 			Func<string, string> valueGetter = MockRepository.GenerateStrictMock<Func<string, string>>();
 			valueGetter.Stub(x => x("bar")).Return("foo").Repeat.Once();
-			KeyValueCache<string, string> keyValueCache = new KeyValueCache<string, string>(valueGetter);
+			IKeyValueCache<string, string> keyValueCache = new KeyValueCache<string, string>(valueGetter);
 			keyValueCache.GetValue("bar"); // Place the value in the cache
 
 			// Act
@@ -46,7 +46,7 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 			// Arrange
 			Func<string, string> valueGetter = MockRepository.GenerateStrictMock<Func<string, string>>();
 			valueGetter.Stub(x => x("bar")).Return(null).Repeat.Twice();
-			KeyValueCache<string, string> keyValueCache = new KeyValueCache<string, string>(valueGetter);
+			IKeyValueCache<string, string> keyValueCache = new KeyValueCache<string, string>(valueGetter);
 			keyValueCache.GetValue("bar"); // Place null in the cache
 
 			// Act
@@ -63,7 +63,7 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 			// Arrange
 			Func<string, string> valueGetter = MockRepository.GenerateStrictMock<Func<string, string>>();
 			valueGetter.Stub(x => x("bar")).Return(null).Repeat.Once();
-			KeyValueCache<string, string> keyValueCache = new KeyValueCache<string, string>(valueGetter);
+			IKeyValueCache<string, string> keyValueCache = new KeyValueCache<string, string>(valueGetter);
 			keyValueCache.GetValue("bar"); // Place null in the cache
 			valueGetter.Stub(x => x("bar")).Return("foo").Repeat.Once();
 			keyValueCache.GetValue("bar"); // Place a non null value in the cahce
@@ -75,5 +75,62 @@ namespace SourcemapToolkit.CallstackDeminifier.UnitTests
 			Assert.Equal("foo", result);
 			valueGetter.VerifyAllExpectations();
 		}
+
+		[Fact]
+		public void GetValue_ChangeValueGetter()
+		{
+			// Arrange
+			Func<string, string> valueGetter = MockRepository.GenerateStrictMock<Func<string, string>>();
+			valueGetter.Stub(x => x("bar")).Return(null);
+			IKeyValueCache<string, string> keyValueCache = new KeyValueCache<string, string>(valueGetter);
+
+			// Act
+			string result = keyValueCache.GetValue("bar");
+
+			// Assert
+			Assert.Null(result);
+
+			// SetValueGetter 
+			Func<string, string> valueGetter2 = MockRepository.GenerateStrictMock<Func<string, string>>();
+			valueGetter2.Stub(x => x("bar")).Return("foo");
+			keyValueCache.SetValueGetter(valueGetter2);
+
+			// Act
+			string result2 = keyValueCache.GetValue("bar");
+
+			// Assert
+			Assert.Equal("foo", result2);
+		}
+
+		[Fact]
+		public void GetValue_CallGetTwice_OnlyCallValueGetterOnce_ChangeValueGetter()
+		{
+			// Arrange
+			Func<string, string> valueGetter = MockRepository.GenerateStrictMock<Func<string, string>>();
+			valueGetter.Stub(x => x("bar")).Return("foo").Repeat.Once();
+			IKeyValueCache<string, string> keyValueCache = new KeyValueCache<string, string>(valueGetter);
+			keyValueCache.GetValue("bar"); // Place the value in the cache
+
+			// Act
+			string result = keyValueCache.GetValue("bar");
+
+			// Assert
+			Assert.Equal("foo", result);
+			valueGetter.VerifyAllExpectations();
+
+			// SetValueGetter
+			Func<string, string> valueGetter2 = MockRepository.GenerateStrictMock<Func<string, string>>();
+			valueGetter2.Stub(x => x("bar2")).Return("foo2").Repeat.Once();
+			keyValueCache.SetValueGetter(valueGetter2);
+			keyValueCache.GetValue("bar2"); // Place the value in the cache
+
+			// Act
+			string result2 = keyValueCache.GetValue("bar2");
+
+			// Assert
+			Assert.Equal("foo2", result2);
+			valueGetter2.VerifyAllExpectations();
+		}
+
 	}
 }


### PR DESCRIPTION
the most memory consumer object we have is the "_cache" property in KeyValueCache

this is Dictionary which holds in the memory all SourceMaps that were called once.

in order to allow users of this package to manage their memory and cache (e.g. eviction of keys in that cache), the best is to allow to set external KeyValueCache object, and let the user handle the cache.

to do so, I create public interface IKeyValueCache, which the current KeyValueCache is implementing
also, added new API signature :
GetMapOnlyStackTraceDeminfier(ISourceMapProvider sourceMapProvider, IStackTraceParser stackTraceParser, IKeyValueCache<string, SourceMap> keyValueCache = null, bool removeSourcesContent = false)

this one is also taking keyValueCache  object, and setting it inside SourceMapStore, and also using SetValueGetter to set the function that allows getting new values and save it to the cache
